### PR TITLE
[Feature] KCISA JSON 수집/파싱/업서트 자동 적재 + uniqueKey 도입 + 대용량 버퍼 설정

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -54,6 +54,9 @@ dependencies {
 	annotationProcessor("org.projectlombok:lombok")
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 
+	// WebClient
+	implementation("org.springframework.boot:spring-boot-starter-webflux")
+
 	// ✅ Test 관련
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")

--- a/backend/src/main/java/com/backend/petplace/domain/place/dto/KcisaDto.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/dto/KcisaDto.java
@@ -1,0 +1,28 @@
+package com.backend.petplace.domain.place.dto;
+
+import java.util.List;
+
+public record KcisaDto(Response response) {
+
+  public record Response(Header header, Body body) {}
+
+  public record Header(String resultCode, String resultMsg) {}
+
+  public record Body(Items items, String numOfRows, String pageNo, String totalCount) {}
+
+  public record Items(List<Item> item) {}
+
+  public record Item(
+      String title,
+      String issuedDate,
+      String category1,
+      String category2,
+      String category3,
+      String description,
+      String tel,
+      String url,
+      String address,
+      String coordinates,
+      String charge
+  ) {}
+}

--- a/backend/src/main/java/com/backend/petplace/domain/place/entity/Place.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/entity/Place.java
@@ -85,4 +85,27 @@ public class Place extends BaseEntity {
     this.totalReviewCount++;
     this.averageRating = (totalScore + newRating) / this.totalReviewCount;
   }
+
+  // 업서트 업데이트 시 필드 동기화 메서드
+  public void apply(String name, Category1Type c1, Category2Type c2, String openingHours,
+      String closedDays, Boolean parking, Boolean petAllowed, String petRestriction,
+      String tel, String url, String postalCode, String address, Double lat, Double lng,
+      String rawDescription
+  ) {
+    this.name = name;
+    this.category1 = c1;
+    this.category2 = c2;
+    this.openingHours = openingHours;
+    this.closedDays = closedDays;
+    this.parking = parking;
+    this.petAllowed = petAllowed;
+    this.petRestriction = petRestriction;
+    this.tel = tel;
+    this.url = url;
+    this.postalCode = postalCode;
+    this.address = address;
+    this.latitude = lat;
+    this.longitude = lng;
+    this.rawDescription = rawDescription;
+  }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/place/entity/Place.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/entity/Place.java
@@ -25,6 +25,10 @@ public class Place extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  // uniqueKey = 장소명 + 우편번호 (중복되는 데이터가 생기는 걸 방지하기 위한 컬럼)
+  @Column(nullable = false, length = 100, unique = true)
+  private String uniqueKey;
+
   @Column(nullable = false, length = 200)
   private String name;
 

--- a/backend/src/main/java/com/backend/petplace/domain/place/entity/mapper/CategoryMapper.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/entity/mapper/CategoryMapper.java
@@ -1,0 +1,25 @@
+package com.backend.petplace.domain.place.entity.mapper;
+
+import static com.backend.petplace.domain.place.entity.Category1Type.*;
+
+import com.backend.petplace.domain.place.entity.Category1Type;
+
+public final class CategoryMapper {
+
+  private CategoryMapper() {
+  }
+
+  public static Category1Type mapCategory1(String koLabel) {
+    if (koLabel == null) {
+      return ETC;
+    }
+    return switch (koLabel.trim()) {
+      case "반려의료" -> PET_MEDICAL;
+      case "반려동반여행" -> PET_TRAVEL;
+      case "반려동물식당카페" -> PET_CAFE_RESTAURANT;
+      case "반려동물 서비스" -> PET_SERVICE;
+      default -> ETC;
+    };
+  }
+
+}

--- a/backend/src/main/java/com/backend/petplace/domain/place/entity/mapper/CategoryMapper.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/entity/mapper/CategoryMapper.java
@@ -1,8 +1,10 @@
 package com.backend.petplace.domain.place.entity.mapper;
 
 import static com.backend.petplace.domain.place.entity.Category1Type.*;
+import static com.backend.petplace.domain.place.entity.Category2Type.*;
 
 import com.backend.petplace.domain.place.entity.Category1Type;
+import com.backend.petplace.domain.place.entity.Category2Type;
 
 public final class CategoryMapper {
 
@@ -18,6 +20,27 @@ public final class CategoryMapper {
       case "반려동반여행" -> PET_TRAVEL;
       case "반려동물식당카페" -> PET_CAFE_RESTAURANT;
       case "반려동물 서비스" -> PET_SERVICE;
+      default -> ETC;
+    };
+  }
+
+  public static Category2Type mapCategory2(String koLabel) {
+    if (koLabel == null) {
+      return ETC;
+    }
+    return switch (koLabel.trim()) {
+      case "동물약국" -> VET_PHARMACY;
+      case "박물관" -> MUSEUM;
+      case "카페" -> CAFE;
+      case "동물병원" -> VET_HOSPITAL;
+      case "반려동물용품" -> PET_SUPPLIES;
+      case "미용" -> GROOMING;
+      case "문예회관" -> ART_CENTER;
+      case "펜션" -> PENSION;
+      case "식당" -> RESTAURANT;
+      case "여행지" -> DESTINATION;
+      case "위탁관리" -> DAYCARE;
+      case "미술관" -> ART_MUSEUM;
       default -> ETC;
     };
   }

--- a/backend/src/main/java/com/backend/petplace/domain/place/entity/mapper/CategoryMapper.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/entity/mapper/CategoryMapper.java
@@ -13,20 +13,20 @@ public final class CategoryMapper {
 
   public static Category1Type mapCategory1(String koLabel) {
     if (koLabel == null) {
-      return ETC;
+      return Category1Type.ETC;
     }
     return switch (koLabel.trim()) {
       case "반려의료" -> PET_MEDICAL;
       case "반려동반여행" -> PET_TRAVEL;
       case "반려동물식당카페" -> PET_CAFE_RESTAURANT;
       case "반려동물 서비스" -> PET_SERVICE;
-      default -> ETC;
+      default -> Category1Type.ETC;
     };
   }
 
   public static Category2Type mapCategory2(String koLabel) {
     if (koLabel == null) {
-      return ETC;
+      return Category2Type.ETC;
     }
     return switch (koLabel.trim()) {
       case "동물약국" -> VET_PHARMACY;
@@ -41,7 +41,7 @@ public final class CategoryMapper {
       case "여행지" -> DESTINATION;
       case "위탁관리" -> DAYCARE;
       case "미술관" -> ART_MUSEUM;
-      default -> ETC;
+      default -> Category2Type.ETC;
     };
   }
 

--- a/backend/src/main/java/com/backend/petplace/domain/place/repository/PlaceRepository.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/repository/PlaceRepository.java
@@ -1,8 +1,13 @@
 package com.backend.petplace.domain.place.repository;
 
 import com.backend.petplace.domain.place.entity.Place;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface PlaceRepository extends JpaRepository<Place, Long> {
+
+  Optional<Place> findByUniqueKey(String uniqueKey);
 
 }

--- a/backend/src/main/java/com/backend/petplace/domain/place/service/KcisaImportService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/service/KcisaImportService.java
@@ -53,32 +53,32 @@ public class KcisaImportService {
 
   /** uniqueKey 기준 업서트 */
   private void upsert(KcisaParser.Parsed f) {
-    var opt = placeRepository.findByUniqueKey(f.getUniqueKey());
+    var opt = placeRepository.findByUniqueKey(f.uniqueKey());
     if (opt.isPresent()) {
       Place e = opt.get();
       e.apply(
-          f.getName(), f.getCategory1(), f.getCategory2(),
-          f.getOpeningHours(), f.getClosedDays(), f.getParking(), f.getPetAllowed(), f.getPetRestriction(),
-          f.getTel(), f.getUrl(), f.getPostalCode(), f.getAddress(), f.getLatitude(), f.getLongitude(), f.getRawDescription()
+          f.name(), f.category1(), f.category2(),
+          f.openingHours(), f.closedDays(), f.parking(), f.petAllowed(), f.petRestriction(),
+          f.tel(), f.url(), f.postalCode(), f.address(), f.latitude(), f.longitude(), f.rawDescription()
       );
     } else {
       Place e = Place.builder()
-          .uniqueKey(f.getUniqueKey())
-          .name(f.getName())
-          .category1(f.getCategory1())
-          .category2(f.getCategory2())
-          .openingHours(f.getOpeningHours())
-          .closedDays(f.getClosedDays())
-          .parking(f.getParking())
-          .petAllowed(f.getPetAllowed())
-          .petRestriction(f.getPetRestriction())
-          .tel(f.getTel())
-          .url(f.getUrl())
-          .postalCode(f.getPostalCode())
-          .address(f.getAddress())
-          .latitude(f.getLatitude())
-          .longitude(f.getLongitude())
-          .rawDescription(f.getRawDescription())
+          .uniqueKey(f.uniqueKey())
+          .name(f.name())
+          .category1(f.category1())
+          .category2(f.category2())
+          .openingHours(f.openingHours())
+          .closedDays(f.closedDays())
+          .parking(f.parking())
+          .petAllowed(f.petAllowed())
+          .petRestriction(f.petRestriction())
+          .tel(f.tel())
+          .url(f.url())
+          .postalCode(f.postalCode())
+          .address(f.address())
+          .latitude(f.latitude())
+          .longitude(f.longitude())
+          .rawDescription(f.rawDescription())
           .build();
       placeRepository.save(e);
     }

--- a/backend/src/main/java/com/backend/petplace/domain/place/service/KcisaImportService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/service/KcisaImportService.java
@@ -1,0 +1,86 @@
+package com.backend.petplace.domain.place.service;
+
+import com.backend.petplace.domain.place.dto.KcisaDto;
+import com.backend.petplace.domain.place.dto.KcisaDto.Item;
+import com.backend.petplace.domain.place.entity.Place;
+import com.backend.petplace.domain.place.repository.PlaceRepository;
+import com.backend.petplace.global.component.KcisaClient;
+import com.backend.petplace.global.component.KcisaParser;
+import com.backend.petplace.global.config.ImportProperties;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class KcisaImportService {
+
+  private final ImportProperties props;
+  private final KcisaClient client;
+  private final KcisaParser parser;
+  private final PlaceRepository placeRepository;
+
+  /**
+   * 전체 페이지를 돌며 적재 (멱등)
+   */
+  @Transactional
+  public int importAll() {
+    int total = 0;
+    for (int page = 1; ; page++) {
+      List<Item> items = client.fetchPage(page);
+      if (items.isEmpty())
+        break;
+
+      for (KcisaDto.Item it : items) {
+        var p = parser.parse(it);
+        upsert(p);
+        total++;
+      }
+
+      // 페이징 종료 판단: 응답 아이템 수가 page-size 미만이면 마지막
+      if (items.size() < props.getPageSize())
+        break;
+
+      // 다음 호출 전 sleep
+      try {
+        Thread.sleep(props.getSleepMs());
+      } catch (InterruptedException ignored) {
+      }
+    }
+    return total;
+  }
+
+  /** uniqueKey 기준 업서트 */
+  private void upsert(KcisaParser.Parsed f) {
+    var opt = placeRepository.findByUniqueKey(f.getUniqueKey());
+    if (opt.isPresent()) {
+      Place e = opt.get();
+      e.apply(
+          f.getName(), f.getCategory1(), f.getCategory2(),
+          f.getOpeningHours(), f.getClosedDays(), f.getParking(), f.getPetAllowed(), f.getPetRestriction(),
+          f.getTel(), f.getUrl(), f.getPostalCode(), f.getAddress(), f.getLatitude(), f.getLongitude(), f.getRawDescription()
+      );
+    } else {
+      Place e = Place.builder()
+          .uniqueKey(f.getUniqueKey())
+          .name(f.getName())
+          .category1(f.getCategory1())
+          .category2(f.getCategory2())
+          .openingHours(f.getOpeningHours())
+          .closedDays(f.getClosedDays())
+          .parking(f.getParking())
+          .petAllowed(f.getPetAllowed())
+          .petRestriction(f.getPetRestriction())
+          .tel(f.getTel())
+          .url(f.getUrl())
+          .postalCode(f.getPostalCode())
+          .address(f.getAddress())
+          .latitude(f.getLatitude())
+          .longitude(f.getLongitude())
+          .rawDescription(f.getRawDescription())
+          .build();
+      placeRepository.save(e);
+    }
+  }
+}

--- a/backend/src/main/java/com/backend/petplace/global/component/KcisaClient.java
+++ b/backend/src/main/java/com/backend/petplace/global/component/KcisaClient.java
@@ -16,23 +16,32 @@ public class KcisaClient {
 
   private final ImportProperties props;
 
-  private final WebClient webClient = WebClient.builder()
-      .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
-      .build();
+  private WebClient webClient() {
+    int bytes = props.getMaxInMemoryMb() * 1024 * 1024;
+
+    return WebClient.builder()
+        .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+        .defaultHeader(HttpHeaders.ACCEPT_ENCODING, "gzip")
+        .codecs(c -> c.defaultCodecs().maxInMemorySize(bytes))
+        .build();
+  }
 
   public List<KcisaDto.Item> fetchPage(int pageNo) {
-    URI uri = URI.create(String.format("%s?serviceKey=%s&numOfRows=%d&pageNo=%d",
-        props.getBaseUrl(), props.getServiceKey(), props.getPageSize(), pageNo));
+    URI uri = URI.create(String.format(
+        "%s?serviceKey=%s&numOfRows=%d&pageNo=%d",
+        props.getBaseUrl(), props.getServiceKey(), props.getPageSize(), pageNo
+    ));
 
-    KcisaDto root = webClient.get()
+    // builder를 매번 새로 만들 필요는 없지만, props 변경 적용 위해 메서드로 분리
+    WebClient client = webClient();
+
+    KcisaDto root = client.get()
         .uri(uri)
         .retrieve()
         .bodyToMono(KcisaDto.class)
         .block();
 
-    if (root == null || root.response() == null || root.response().body() == null) {
-      return List.of();
-    }
+    if (root == null || root.response() == null || root.response().body() == null) return List.of();
     var items = root.response().body().items();
     return (items == null || items.item() == null) ? List.of() : items.item();
   }

--- a/backend/src/main/java/com/backend/petplace/global/component/KcisaClient.java
+++ b/backend/src/main/java/com/backend/petplace/global/component/KcisaClient.java
@@ -1,0 +1,39 @@
+package com.backend.petplace.global.component;
+
+import com.backend.petplace.domain.place.dto.KcisaDto;
+import com.backend.petplace.global.config.ImportProperties;
+import java.net.URI;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@RequiredArgsConstructor
+public class KcisaClient {
+
+  private final ImportProperties props;
+
+  private final WebClient webClient = WebClient.builder()
+      .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+      .build();
+
+  public List<KcisaDto.Item> fetchPage(int pageNo) {
+    URI uri = URI.create(String.format("%s?serviceKey=%s&numOfRows=%d&pageNo=%d",
+        props.getBaseUrl(), props.getServiceKey(), props.getPageSize(), pageNo));
+
+    KcisaDto root = webClient.get()
+        .uri(uri)
+        .retrieve()
+        .bodyToMono(KcisaDto.class)
+        .block();
+
+    if (root == null || root.response() == null || root.response().body() == null) {
+      return List.of();
+    }
+    var items = root.response().body().items();
+    return (items == null || items.item() == null) ? List.of() : items.item();
+  }
+}

--- a/backend/src/main/java/com/backend/petplace/global/component/KcisaParser.java
+++ b/backend/src/main/java/com/backend/petplace/global/component/KcisaParser.java
@@ -1,0 +1,13 @@
+package com.backend.petplace.global.component;
+
+import java.util.regex.Pattern;
+
+public class KcisaParser {
+
+  private static final Pattern COORD_P = Pattern.compile("([NS])\\s*([0-9.]+)\\s*,\\s*([EW])\\s*([0-9.]+)");
+  private static final Pattern POSTAL_P = Pattern.compile("^\\((\\d{5})\\)\\s*(.+)$");
+  private static final Pattern OPENING_P = Pattern.compile("^\\s*운영\\s*시간\\s*:?\\s*(.+)$");
+  private static final Pattern CLOSED_P  = Pattern.compile("^\\s*휴\\s*무\\s*일\\s*:?\\s*(.+)$");
+  private static final Pattern PET_LIMIT_P = Pattern.compile("^\\s*반려동물\\s*제한사항\\s*:?\\s*(.+)$");
+
+}

--- a/backend/src/main/java/com/backend/petplace/global/component/KcisaParser.java
+++ b/backend/src/main/java/com/backend/petplace/global/component/KcisaParser.java
@@ -3,8 +3,6 @@ package com.backend.petplace.global.component;
 import com.backend.petplace.domain.place.entity.Category1Type;
 import com.backend.petplace.domain.place.entity.Category2Type;
 import java.util.regex.Pattern;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
 public class KcisaParser {
 
@@ -23,26 +21,24 @@ public class KcisaParser {
   // 반려동물 제한사항 패턴
   private static final Pattern PET_LIMIT_P = Pattern.compile("^\\s*반려동물\\s*제한사항\\s*:?\\s*(.+)$");
 
-  @Getter
-  @AllArgsConstructor
-  public static class Parsed {
-    private final String name;
-    private final Category1Type category1;
-    private final Category2Type category2;
-    private final String openingHours;
-    private final String closedDays;
-    private final Boolean parking;
-    private final Boolean petAllowed;
-    private final String petRestriction;
-    private final String tel;
-    private final String url;
-    private final String postalCode;
-    private final String address;
-    private final Double latitude;
-    private final Double longitude;
-    private final String rawDescription;
-    private final String uniqueKey;
-  }
+  public record Parsed(
+      String name,
+      Category1Type category1,
+      Category2Type category2,
+      String openingHours,
+      String closedDays,
+      Boolean parking,
+      Boolean petAllowed,
+      String petRestriction,
+      String tel,
+      String url,
+      String postalCode,
+      String address,
+      Double latitude,
+      Double longitude,
+      String rawDescription,
+      String uniqueKey
+  ) {}
 
 
 }

--- a/backend/src/main/java/com/backend/petplace/global/component/KcisaParser.java
+++ b/backend/src/main/java/com/backend/petplace/global/component/KcisaParser.java
@@ -4,10 +4,19 @@ import java.util.regex.Pattern;
 
 public class KcisaParser {
 
+  // 좌표 패턴
   private static final Pattern COORD_P = Pattern.compile("([NS])\\s*([0-9.]+)\\s*,\\s*([EW])\\s*([0-9.]+)");
+
+  // 우편번호 패턴
   private static final Pattern POSTAL_P = Pattern.compile("^\\((\\d{5})\\)\\s*(.+)$");
+
+  // 운영시간 패턴
   private static final Pattern OPENING_P = Pattern.compile("^\\s*운영\\s*시간\\s*:?\\s*(.+)$");
+
+  // 휴무일 패턴
   private static final Pattern CLOSED_P  = Pattern.compile("^\\s*휴\\s*무\\s*일\\s*:?\\s*(.+)$");
+
+  // 반려동물 제한사항 패턴
   private static final Pattern PET_LIMIT_P = Pattern.compile("^\\s*반려동물\\s*제한사항\\s*:?\\s*(.+)$");
 
 }

--- a/backend/src/main/java/com/backend/petplace/global/component/KcisaParser.java
+++ b/backend/src/main/java/com/backend/petplace/global/component/KcisaParser.java
@@ -1,13 +1,20 @@
 package com.backend.petplace.global.component;
 
+import com.backend.petplace.domain.place.dto.KcisaDto;
 import com.backend.petplace.domain.place.entity.Category1Type;
 import com.backend.petplace.domain.place.entity.Category2Type;
+import com.backend.petplace.domain.place.entity.mapper.CategoryMapper;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class KcisaParser {
 
   // 좌표 패턴
-  private static final Pattern COORD_P = Pattern.compile("([NS])\\s*([0-9.]+)\\s*,\\s*([EW])\\s*([0-9.]+)");
+  private static final Pattern COORD_P = Pattern.compile(
+      "([NS])\\s*([0-9.]+)\\s*,\\s*([EW])\\s*([0-9.]+)");
 
   // 우편번호 패턴
   private static final Pattern POSTAL_P = Pattern.compile("^\\((\\d{5})\\)\\s*(.+)$");
@@ -16,7 +23,7 @@ public class KcisaParser {
   private static final Pattern OPENING_P = Pattern.compile("^\\s*운영\\s*시간\\s*:?\\s*(.+)$");
 
   // 휴무일 패턴
-  private static final Pattern CLOSED_P  = Pattern.compile("^\\s*휴\\s*무\\s*일\\s*:?\\s*(.+)$");
+  private static final Pattern CLOSED_P = Pattern.compile("^\\s*휴\\s*무\\s*일\\s*:?\\s*(.+)$");
 
   // 반려동물 제한사항 패턴
   private static final Pattern PET_LIMIT_P = Pattern.compile("^\\s*반려동물\\s*제한사항\\s*:?\\s*(.+)$");
@@ -40,5 +47,115 @@ public class KcisaParser {
       String uniqueKey
   ) {}
 
+  public Parsed parse(KcisaDto.Item it) {
+    //  주소/우편번호
+    String postal = null, addr = null;
+    if (it.address() != null) {
+      Matcher m = POSTAL_P.matcher(it.address().trim());
+      if (m.find()) {
+        postal = m.group(1);
+        addr = m.group(2);
+      } else {
+        addr = it.address().trim();
+      }
+    }
 
+    // 좌표
+    Double lat = null, lng = null;
+    if (it.coordinates() != null) {
+      Matcher m = COORD_P.matcher(it.coordinates());
+      if (m.find()) {
+        lat = Double.parseDouble(m.group(2)) * ("S".equalsIgnoreCase(m.group(1)) ? -1 : 1);
+        lng = Double.parseDouble(m.group(4)) * ("W".equalsIgnoreCase(m.group(3)) ? -1 : 1);
+      }
+    }
+
+    // description 토큰 파싱
+    String opening = null, closed = null, petLimit = null;
+    Boolean parking = null, petAllowed = null;
+    if (it.description() != null && !it.description().isBlank()) {
+      String[] tokens = it.description().split("\\|");
+      for (String raw : tokens) {
+        String s = raw.trim();
+        if (OPENING_P.matcher(s).find()) {
+          opening = s.replaceFirst("^\\s*운영\\s*시간\\s*:?\\s*", "").trim();
+        } else if (CLOSED_P.matcher(s).find()) {
+          closed = s.replaceFirst("^\\s*휴\\s*무\\s*일\\s*:?\\s*", "").trim();
+        } else if (s.contains("주차가능")) {
+          parking = true;
+        } else if (s.contains("주차 불가")) {
+          parking = false;
+        } else if (s.contains("동반가능")) {
+          petAllowed = true;
+        } else if (s.contains("동반불가")) {
+          petAllowed = false;
+        } else if (PET_LIMIT_P.matcher(s).find()) {
+          petLimit = s.replaceFirst("^\\s*반려동물\\s*제한사항\\s*:?\\s*", "").trim();
+        }
+      }
+    }
+
+    // tel/url
+    String tel = it.tel() == null ? null : it.tel().replaceAll("[^0-9-]", "");
+    String url = normalizeUrl(it.url());
+
+    // 카테고리 매핑
+    Category1Type c1 = CategoryMapper.mapCategory1(it.category1());
+    Category2Type c2 = CategoryMapper.mapCategory2(it.category2());
+
+    // uniqueKey: title + 우편번호(없으면 주소) → SHA-256 해싱
+    String uniqueKey = buildUniqueKey(it.title(), postal, addr);
+
+    return new Parsed(
+        it.title(), c1, c2, opening, closed, parking, petAllowed, petLimit, tel, url, postal, addr,
+        lat, lng, it.description(), uniqueKey
+    );
+  }
+
+  private static String normalizeTitle(String t) {
+    if (t == null) {
+      return "";
+    }
+    return t.trim().toLowerCase().replaceAll("\\s+", " ");
+  }
+
+  private static String normalizeAddrForKey(String addr) {
+    if (addr == null) {
+      return "";
+    }
+    return addr.trim().toLowerCase().replaceAll("\\s+", " ");
+  }
+
+  private static String buildUniqueKey(String title, String postal, String addr) {
+    String t = normalizeTitle(title);
+    String base = (postal != null && !postal.isBlank())
+        ? (t + "|" + postal)
+        : (t + "|" + normalizeAddrForKey(addr));
+    return sha256Hex(base);
+  }
+
+  private static String normalizeUrl(String u) {
+    if (u == null || u.isBlank()) {
+      return null;
+    }
+    String s = u.trim();
+    if (!s.matches("^(?i)https?://.*")) {
+      s = "http://" + s;
+    }
+    return s;
+  }
+
+  private static String sha256Hex(String s) {
+    try {
+      MessageDigest md = MessageDigest.getInstance("SHA-256");
+      byte[] out = md.digest(s.getBytes(StandardCharsets.UTF_8));
+      StringBuilder sb = new StringBuilder();
+      for (byte b : out) {
+        sb.append(String.format("%02x", b));
+      }
+      return sb.toString();
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 not available", e);
+    }
+  }
 }

--- a/backend/src/main/java/com/backend/petplace/global/component/KcisaParser.java
+++ b/backend/src/main/java/com/backend/petplace/global/component/KcisaParser.java
@@ -9,7 +9,9 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
 
+@Component
 public class KcisaParser {
 
   // 좌표 패턴

--- a/backend/src/main/java/com/backend/petplace/global/component/KcisaParser.java
+++ b/backend/src/main/java/com/backend/petplace/global/component/KcisaParser.java
@@ -1,6 +1,10 @@
 package com.backend.petplace.global.component;
 
+import com.backend.petplace.domain.place.entity.Category1Type;
+import com.backend.petplace.domain.place.entity.Category2Type;
 import java.util.regex.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 public class KcisaParser {
 
@@ -18,5 +22,27 @@ public class KcisaParser {
 
   // 반려동물 제한사항 패턴
   private static final Pattern PET_LIMIT_P = Pattern.compile("^\\s*반려동물\\s*제한사항\\s*:?\\s*(.+)$");
+
+  @Getter
+  @AllArgsConstructor
+  public static class Parsed {
+    private final String name;
+    private final Category1Type category1;
+    private final Category2Type category2;
+    private final String openingHours;
+    private final String closedDays;
+    private final Boolean parking;
+    private final Boolean petAllowed;
+    private final String petRestriction;
+    private final String tel;
+    private final String url;
+    private final String postalCode;
+    private final String address;
+    private final Double latitude;
+    private final Double longitude;
+    private final String rawDescription;
+    private final String uniqueKey;
+  }
+
 
 }

--- a/backend/src/main/java/com/backend/petplace/global/config/ImportProperties.java
+++ b/backend/src/main/java/com/backend/petplace/global/config/ImportProperties.java
@@ -1,0 +1,19 @@
+package com.backend.petplace.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "import")
+public class ImportProperties {
+
+  private boolean enabled;
+  private String baseUrl;
+  private String serviceKey;
+  private int pageSize = 10_000;
+  private long sleepMs = 200L;
+}

--- a/backend/src/main/java/com/backend/petplace/global/config/ImportProperties.java
+++ b/backend/src/main/java/com/backend/petplace/global/config/ImportProperties.java
@@ -16,4 +16,5 @@ public class ImportProperties {
   private String serviceKey;
   private int pageSize = 10_000;
   private long sleepMs = 200L;
+  private int maxInMemoryMb = 16;
 }

--- a/backend/src/main/java/com/backend/petplace/global/config/ImportProperties.java
+++ b/backend/src/main/java/com/backend/petplace/global/config/ImportProperties.java
@@ -14,7 +14,7 @@ public class ImportProperties {
   private boolean enabled;
   private String baseUrl;
   private String serviceKey;
-  private int pageSize = 10_000;
-  private long sleepMs = 200L;
-  private int maxInMemoryMb = 16;
+  private int pageSize;
+  private long sleepMs;
+  private int maxInMemoryMb;
 }

--- a/backend/src/main/java/com/backend/petplace/global/initdata/KcisaImportRunner.java
+++ b/backend/src/main/java/com/backend/petplace/global/initdata/KcisaImportRunner.java
@@ -1,0 +1,24 @@
+package com.backend.petplace.global.initdata;
+
+import com.backend.petplace.domain.place.service.KcisaImportService;
+import com.backend.petplace.global.config.ImportProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "import", name = "enabled", havingValue = "true")
+public class KcisaImportRunner implements ApplicationRunner {
+
+  private final KcisaImportService service;
+  private final ImportProperties props;
+
+  @Override
+  public void run(ApplicationArguments args) {
+    int count = service.importAll();
+    System.out.printf("[KCISA IMPORT] imported=%d (pageSize=%d)%n", count, props.getPageSize());
+  }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -36,6 +36,13 @@ cloud:
     stack:
       auto: false
 
+import:
+  enabled: true         # 로컬 최초 적재 시 true, 이후 false로 끄기
+  base-url: https://api.kcisa.kr/openapi/API_TOU_050/request
+  service-key: ${KCISA_SERVICE_KEY}
+  page-size: ${KCISA_PAGE_SIZE}
+  sleep-ms: ${KCISA_SLEEP_MS}
+
 springdoc:
   default-produces-media-type: application/json
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -45,6 +45,7 @@ import:
   service-key: ${KCISA_SERVICE_KEY}
   page-size: ${KCISA_PAGE_SIZE}
   sleep-ms: ${KCISA_SLEEP_MS}
+  max-in-memory-mb: ${KCISA_MAX_IN_MEMORY_MB}
 
 springdoc:
   default-produces-media-type: application/json

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -22,6 +22,9 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 50MB
+  http:
+    codecs:
+      max-in-memory-size: 16MB
 
 cloud:
   aws:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -40,7 +40,7 @@ cloud:
       auto: false
 
 import:
-  enabled: true         # 로컬 최초 적재 시 true, 이후 false로 끄기
+  enabled: false         # 로컬 최초 적재 시 true, 이후 false로 끄기
   base-url: https://api.kcisa.kr/openapi/API_TOU_050/request
   service-key: ${KCISA_SERVICE_KEY}
   page-size: ${KCISA_PAGE_SIZE}


### PR DESCRIPTION
## 📌 관련 이슈
- close #51 

## 📝 변경 사항
### AS-IS
* 외부 데이터 초기 적재, **자동화 부재**.
* Place 엔티티에 중복 판별 키 없음 → 재실행 시 **중복 저장 위험**.

### TO-BE
* **자동 적재 파이프라인 완성**: 앱 시작 시(import.enabled=true) → API 호출 → 파싱 → **업서트 저장**.
* **uniqueKey(sha-256)** 도입: `title + (우편번호 || 주소)` 기반, DB `unique` 제약으로 **중복 방지/멱등 보장**.
* **파싱 표준화**: 주소/우편번호/좌표/description(운영시간·휴무일·주차·동반가능·제한사항) **느슨한 정규식 파서**.
* **안정성 강화**:

  * `spring.codec.max-in-memory-size: 16MB`(전역) + WebClient `.maxInMemorySize(...)`
  * `page-size(1000)` + `sleepMs`로 딜레이
* **토글 가능**: 최초 적재 후 `import.enabled=false`로 손쉬운 **비활성화**.

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
  * Postman으로 `Accept: application/json` 헤더 확인
  * `pageNo=1..n`, `numOfRows={page-size}` 로 실제 호출 → 정상 파싱 확인
- [x] 로컬 테스트
  * `import.enabled=true`로 최초 실행 → 콘솔 로그 `[KCISA IMPORT] imported=...`
  * `import.enabled=false`로 재기동 → API 미호출 확인
  * `KCISA_PAGE_SIZE` 값을 1000 등으로 바꿔 정상 동작 확인
  * 대용량에서도 `DataBufferLimitException` 미발생 확인

## 📸 스크린샷
- import.enabled=true 로 최초 적재 데이터 확인
  * 1 ~ 1000(첫 페이지)
  
<img width="2526" height="1366" alt="image" src="https://github.com/user-attachments/assets/6806adc8-85a9-4b31-b390-ac4362bfea2b" />

  * 23000 ~ 23920(마지막 페이지)
<img width="2502" height="1332" alt="image" src="https://github.com/user-attachments/assets/46bf4cb7-9f71-42ae-ac62-2ace68ca781b" />
<img width="2508" height="380" alt="image" src="https://github.com/user-attachments/assets/84acffe5-4cd2-4322-8c5c-218a2aeac211" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 데이터 처음 적재 할때는 application.yml 파일의  import.enabled=true 로 설정하시고 그 후에는 false로 바꿔주셔야 합니다!
- 현재 패키지 구조가 좀 엉망인데 이 부분은 다음 PR에서 코드 리팩토링 하면서 패키지 구조도 함께 수정하겠습니다.
- 이번 PR 내용이 좀 많은 것 같습니다,, 최대한 쪼개보려고 했는데 다 연관이 되어 있는 기능들이라서 참고 부탁드립니다!


