### PR TITLE
[Feature] 1인 유저의 주문내역 모두 조회

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderController.java
@@ -1,11 +1,14 @@
 package com.backend.petplace.domain.order.controller;
 
 import com.backend.petplace.domain.order.dto.request.OrderCreateRequest;
+import com.backend.petplace.domain.order.dto.response.OrderReadByIdResponse;
 import com.backend.petplace.domain.order.service.OrderService;
 import com.backend.petplace.global.response.ApiResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,5 +29,14 @@ public class OrderController {
     orderService.createOrder(request, userId);
 
     return ResponseEntity.ok(ApiResponse.success());
+  }
+
+  @GetMapping(value = "/orders")
+  public ResponseEntity<ApiResponse<List<OrderReadByIdResponse>>> getOrderById(
+      @CookieValue("userId") Long userId) {
+
+    List<OrderReadByIdResponse> responses = orderService.getOrdersByUserId(userId);
+
+    return ResponseEntity.ok(ApiResponse.success(responses));
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/order/dto/response/OrderReadByIdResponse.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/dto/response/OrderReadByIdResponse.java
@@ -1,0 +1,40 @@
+package com.backend.petplace.domain.order.dto.response;
+
+import com.backend.petplace.domain.order.entity.Order;
+import com.backend.petplace.domain.order.entity.OrderStatus;
+import com.backend.petplace.domain.orderproduct.entity.OrderProduct;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class OrderReadByIdResponse {
+
+  private Long orderId;
+  private LocalDateTime updatedAt;
+  private OrderStatus orderStatus;
+  private Long totalPrice;
+  private List<OrderProductDto> orderProducts;
+
+  public OrderReadByIdResponse(Order order) {
+    this.orderId = order.getOrderId();
+    this.updatedAt = order.getModifiedDate();
+    this.orderStatus = order.getOrderStatus();
+    this.totalPrice = order.getTotalPrice();
+    this.orderProducts = order.getOrderProducts().stream()
+        .map(OrderProductDto::new)
+        .toList();
+  }
+
+  @Getter
+  public static class OrderProductDto {
+
+    private String productName;
+    private long quantity;
+
+    public OrderProductDto(OrderProduct orderProduct) {
+      this.productName = orderProduct.getProduct().getProductName();
+      this.quantity = orderProduct.getQuantity();
+    }
+  }
+}

--- a/backend/src/main/java/com/backend/petplace/domain/order/repository/OrderRepository.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/repository/OrderRepository.java
@@ -1,8 +1,9 @@
 package com.backend.petplace.domain.order.repository;
 
 import com.backend.petplace.domain.order.entity.Order;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
-
+  List<Order> findByUserId(Long userId);
 }

--- a/backend/src/main/java/com/backend/petplace/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/service/OrderService.java
@@ -1,6 +1,7 @@
 package com.backend.petplace.domain.order.service;
 
 import com.backend.petplace.domain.order.dto.request.OrderCreateRequest;
+import com.backend.petplace.domain.order.dto.response.OrderReadByIdResponse;
 import com.backend.petplace.domain.order.entity.Order;
 import com.backend.petplace.domain.order.repository.OrderRepository;
 import com.backend.petplace.domain.orderproduct.dto.request.OrderProductCreateRequest;
@@ -82,5 +83,13 @@ public class OrderService {
     if (orderProductRequest.getQuantity() > product.getStock()) {
       throw new BusinessException(ErrorCode.NOT_ENOUGH_STOCK);
     }
+  }
+
+  public List<OrderReadByIdResponse> getOrdersByUserId(Long userId) {
+    List<Order> orders = orderRepository.findByUserId(userId);
+
+    return orders.stream()
+        .map(OrderReadByIdResponse::new) // Order -> DTO 변환
+        .toList();
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/product/entity/Product.java
+++ b/backend/src/main/java/com/backend/petplace/domain/product/entity/Product.java
@@ -20,6 +20,9 @@ public class Product extends BaseEntity {
   private Long productId;
 
   @Column(nullable = false)
+  private String productName;
+
+  @Column(nullable = false)
   private Long price;
 
   @Column(nullable = false)
@@ -29,15 +32,17 @@ public class Product extends BaseEntity {
 
 
   @Builder
-  public Product(Long price, Long stock, String description) {
+  public Product(String productName, Long price, Long stock, String description) {
+    this.productName = productName;
     this.price = price;
     this.stock = stock;
     this.description = description;
   }
 
   //정적 팩토리 메서드를 통한 product 객체 생성
-  public static Product createProduct(Long price, Long stock, String description) {
+  public static Product createProduct(String productName, Long price, Long stock, String description) {
     return Product.builder()
+        .productName(productName)
         .price(price)
         .stock(stock)
         .description(description)

--- a/backend/src/main/java/com/backend/petplace/global/initdata/BaseInitData.java
+++ b/backend/src/main/java/com/backend/petplace/global/initdata/BaseInitData.java
@@ -13,27 +13,31 @@ public class BaseInitData implements CommandLineRunner {
   private final ProductRepository productRepository;
 
   @Override
-  public void run(String... args) throws Exception {
+  public void run(String... args) {
 
     Product p1 = Product.builder()
+        .productName("상품 1")
         .price(150L)
         .stock(9999L)
         .description("상품 1")
         .build();
 
     Product p2 = Product.builder()
+        .productName("상품 2")
         .price(80L)
         .stock(9999L)
         .description("상품 2")
         .build();
 
     Product p3 = Product.builder()
+        .productName("상품 3")
         .price(120L)
         .stock(9999L)
         .description("상품 3")
         .build();
 
     Product p4 = Product.builder()
+        .productName("상품 4")
         .price(200L)
         .stock(9999L)
         .description("상품 4")


### PR DESCRIPTION
- 1. Dto, 컨트롤러, 서비스, 레포지토리 코드 개발
- 2. Product 엔티티에 누락된 'productName' 추가
- 3. 2에 맞춰 기본 상품 생성 시 productName 추가

## 📌 관련 이슈
- close #54 

## 📝 변경 사항
### AS-IS
- 기존 코드의 동작 방식 설명: 
- 1인의 주문내역 조회 기능 부재
<br></br>
- 기존의 문제점 설명
- 사용자가 자신의 주문내역 조회할 수 없다.
<br></br>
### TO-BE
- 변경된 내용 설명
- 주문내역 조회 기능 추가
<br></br>
- 문제가 해결된 방식 설명
- DTO, 컨트롤러, 서비스, 레포지토리 코드 추가
- product 엔티티 클래스에 고객에게 보일 productName 필드 추가
- baseInitData에 미리 생성해놓을 product들도 productName 필드 초기화.
<br></br>
## 🔍 테스트
- [ ] 테스트 코드 작성
- [X] API 테스트
- [ ] 로컬 테스트
<br></br>
## 📸 스크린샷
<img width="1601" height="823" alt="2025-10-20 14 18 57" src="https://github.com/user-attachments/assets/d90382b8-844e-4341-9816-ca8d26f050c7" />


<br></br>
## ✅ 체크리스트
- [X] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [X] 코딩 컨벤션을 준수했나요?
- [X] 불필요한 코드는 제거했나요?
- [X] 주석은 충분히 작성했나요?
- [X] 테스트는 완료했나요?
<br></br>
## 🙋‍♂️ 리뷰어에게
리뷰 환영합니다!
<br></br>

