### PR TITLE
feat : 주문 단건의 상태를 ORDERED에서 CANCELED로 업데이트

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderController.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,5 +40,16 @@ public class OrderController {
     List<OrderReadByIdResponse> responses = orderService.getOrdersByUserId(userId);
 
     return ResponseEntity.ok(ApiResponse.success(responses));
+  }
+
+  @PatchMapping("/orders/{orderid}/cancel")
+  public ResponseEntity<ApiResponse<Void>> cancelOrder(
+      @PathVariable("orderid") Long orderId,
+      @CookieValue("userId") Long userId
+
+  ) {
+    orderService.cancelOrder(userId, orderId);
+
+    return ResponseEntity.ok(ApiResponse.success());
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/entity/Order.java
@@ -3,6 +3,8 @@ package com.backend.petplace.domain.order.entity;
 import com.backend.petplace.domain.orderproduct.entity.OrderProduct;
 import com.backend.petplace.domain.user.entity.User;
 import com.backend.petplace.global.entity.BaseEntity;
+import com.backend.petplace.global.exception.BusinessException;
+import com.backend.petplace.global.response.ErrorCode;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -90,5 +92,12 @@ public class Order extends BaseEntity {
     if (user != null && !user.getOrders().contains(this)) { // 아직 연결 안 되어 있으면
       user.getOrders().add(this);        // User 쪽 리스트에도 추가
     }
+  }
+
+  public void cancelOrder() {
+    if (this.orderStatus != OrderStatus.ORDERED) {
+      throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
+    }
+    this.orderStatus = OrderStatus.CANCELED;
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/entity/Order.java
@@ -95,9 +95,7 @@ public class Order extends BaseEntity {
   }
 
   public void cancelOrder() {
-    if (this.orderStatus != OrderStatus.ORDERED) {
-      throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
-    }
+
     this.orderStatus = OrderStatus.CANCELED;
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/service/OrderService.java
@@ -98,11 +98,11 @@ public class OrderService {
     Order order = orderRepository.findById(orderId)
         .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_ORDER));
 
-    order.cancelOrder();
-
     if (order.getOrderStatus() != OrderStatus.ORDERED) {
       throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
     }
+
+    order.cancelOrder();
 
     orderRepository.save(order);
   }

--- a/backend/src/main/java/com/backend/petplace/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/service/OrderService.java
@@ -92,4 +92,15 @@ public class OrderService {
         .map(OrderReadByIdResponse::new) // Order -> DTO 변환
         .toList();
   }
+
+  public void cancelOrder(Long userId, Long orderId) {
+    Order order = orderRepository.findById(orderId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_ORDER));
+
+    order.cancelOrder();
+
+    orderRepository.save(order);
+  }
+
+
 }

--- a/backend/src/main/java/com/backend/petplace/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/service/OrderService.java
@@ -3,6 +3,7 @@ package com.backend.petplace.domain.order.service;
 import com.backend.petplace.domain.order.dto.request.OrderCreateRequest;
 import com.backend.petplace.domain.order.dto.response.OrderReadByIdResponse;
 import com.backend.petplace.domain.order.entity.Order;
+import com.backend.petplace.domain.order.entity.OrderStatus;
 import com.backend.petplace.domain.order.repository.OrderRepository;
 import com.backend.petplace.domain.orderproduct.dto.request.OrderProductCreateRequest;
 import com.backend.petplace.domain.orderproduct.entity.OrderProduct;
@@ -98,6 +99,10 @@ public class OrderService {
         .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_ORDER));
 
     order.cancelOrder();
+
+    if (order.getOrderStatus() != OrderStatus.ORDERED) {
+      throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
+    }
 
     orderRepository.save(order);
   }

--- a/backend/src/main/java/com/backend/petplace/global/response/ErrorCode.java
+++ b/backend/src/main/java/com/backend/petplace/global/response/ErrorCode.java
@@ -29,6 +29,9 @@ public enum ErrorCode {
   NOT_FOUND_PRODUCT("ORO002", HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다."),
   NOT_ENOUGH_STOCK("ORO003", HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
   NOT_ENOUGH_POINT("ORO004", HttpStatus.BAD_REQUEST, "포인트가 부족합니다."),
+  NOT_FOUND_ORDER("ORO005", HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다."),
+  INVALID_ORDER_STATUS("ORO006", HttpStatus.BAD_REQUEST, "취소할 수 없는 주문 상태입니다."),
+
   // 반려동물
   NOT_FOUND_PET("PET001", HttpStatus.NOT_FOUND, "존재하지 않는 반려동물입니다.");
 


### PR DESCRIPTION
- 관련 컨트롤러,서비스,레포지토리 코드 작성
- 예외 처리 위한 ErrorCode 추가
- 각각 성공, 예외 테스트 성공
<br></br>
## 📌 관련 이슈
- close #58 
<br></br>
## 📝 변경 사항
### AS-IS
- 기존 코드의 동작 방식 설명
- 1. 주문(Order) 상태가 ORDERED로 고정.
<br></br>
- 기존의 문제점 설명
- 1. 시나리오 상 고객이 취소할 수 있어야 한다.

<br></br>
### TO-BE
- 변경된 내용 설명
- 1. 주문을 취소 상태로 업데이트 요청 가능.
<br></br>
- 문제가 해결된 방식 설명
- 1. OrderController, OrderService, OrderRepository 코드 변경.
- 2. Order 엔티티에 cancelOrder() 함수 생성.
- 3. 관련 에러코드 작성.
<br></br>
## 🔍 테스트
- [ ] 테스트 코드 작성
- [X] API 테스트
- [ ] 로컬 테스트

<br></br>
## 📸 스크린샷
- 요청 전 (ORDERED 상태)
<img width="1910" height="831" alt="전송 전" src="https://github.com/user-attachments/assets/d2f57f81-9241-40f1-8798-8446fdb8341a" />


- 요청 후 (CANCELED 상태)
<img width="1833" height="796" alt="전송 후" src="https://github.com/user-attachments/assets/6fe8bbf8-5d23-4059-8a1c-36db859588e6" />

- 예외처리 (ORDERED가 아니면 예외처리됨)
<img width="1874" height="820" alt="예외처리" src="https://github.com/user-attachments/assets/59f187c1-3479-48d5-975d-79a4cf19671a" />


<br></br>
## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

<br></br>
## 🙋‍♂️ 리뷰어에게
- 파라미터 딱 1개면 dto 대신 @PathVariable("orderid") Long orderId로 받아오는 게 맞죠?
- Swagger는 리팩토링때 모아서 하겠습니다

<br></br>
