### PR TITLE
[Feature] 장소 상세 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceController.java
@@ -1,12 +1,23 @@
 package com.backend.petplace.domain.place.controller;
 
+import com.backend.petplace.domain.place.service.PlaceService;
+import com.backend.petplace.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("api/v1/ ")
+@RequestMapping("api/v1/places")
 @RequiredArgsConstructor
 public class PlaceController {
 
+  private final PlaceService placeService;
+
+  @GetMapping("/{id}")
+  public ResponseEntity<ApiResponse<PlaceDetailResponse>> getPlaceDetail(Long id) {
+
+    return ResponseEntity.ok(ApiResponse.success(placeService.getPlaceDetail));
+  }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceController.java
@@ -3,6 +3,7 @@ package com.backend.petplace.domain.place.controller;
 import com.backend.petplace.domain.place.dto.response.PlaceDetailResponse;
 import com.backend.petplace.domain.place.service.PlaceService;
 import com.backend.petplace.global.response.ApiResponse;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,7 +19,8 @@ public class PlaceController implements PlaceSpecification{
   private final PlaceService placeService;
 
   @GetMapping("/{placeId}")
-  public ResponseEntity<ApiResponse<PlaceDetailResponse>> getPlaceDetail(@PathVariable Long placeId) {
+  public ResponseEntity<ApiResponse<PlaceDetailResponse>> getPlaceDetail(
+      @PathVariable @Positive Long placeId) {
 
     return ResponseEntity.ok(ApiResponse.success(placeService.getPlaceDetail(placeId)));
   }

--- a/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceController.java
@@ -18,6 +18,7 @@ public class PlaceController implements PlaceSpecification{
 
   private final PlaceService placeService;
 
+  @Override
   @GetMapping("/{placeId}")
   public ResponseEntity<ApiResponse<PlaceDetailResponse>> getPlaceDetail(
       @PathVariable @Positive Long placeId) {

--- a/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceController.java
@@ -1,5 +1,6 @@
 package com.backend.petplace.domain.place.controller;
 
+import com.backend.petplace.domain.place.dto.response.PlaceDetailResponse;
 import com.backend.petplace.domain.place.service.PlaceService;
 import com.backend.petplace.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceController.java
@@ -5,19 +5,20 @@ import com.backend.petplace.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("api/v1/places")
 @RequiredArgsConstructor
-public class PlaceController {
+public class PlaceController implements PlaceSpecification{
 
   private final PlaceService placeService;
 
   @GetMapping("/{id}")
-  public ResponseEntity<ApiResponse<PlaceDetailResponse>> getPlaceDetail(Long id) {
+  public ResponseEntity<ApiResponse<PlaceDetailResponse>> getPlaceDetail(@PathVariable Long id) {
 
-    return ResponseEntity.ok(ApiResponse.success(placeService.getPlaceDetail));
+    return ResponseEntity.ok(ApiResponse.success(placeService.getPlaceDetail(id)));
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceController.java
@@ -17,9 +17,9 @@ public class PlaceController implements PlaceSpecification{
 
   private final PlaceService placeService;
 
-  @GetMapping("/{id}")
-  public ResponseEntity<ApiResponse<PlaceDetailResponse>> getPlaceDetail(@PathVariable Long id) {
+  @GetMapping("/{placeId}")
+  public ResponseEntity<ApiResponse<PlaceDetailResponse>> getPlaceDetail(@PathVariable Long placeId) {
 
-    return ResponseEntity.ok(ApiResponse.success(placeService.getPlaceDetail(id)));
+    return ResponseEntity.ok(ApiResponse.success(placeService.getPlaceDetail(placeId)));
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceSpecification.java
@@ -1,0 +1,16 @@
+package com.backend.petplace.domain.place.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Place", description = "장소 API")
+public interface PlaceSpecification {
+
+  @Operation(summary = "장소 상세 조회", description = "장소 ID로 상세 정보를 조회합니다.")
+  ResponseEntity<ApiResponse<PlaceDetailResponse>> getPlaceDetail(
+      @Parameter(in = ParameterIn.PATH, description = "장소 ID", required = true) Long id
+  );
+
+}

--- a/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceSpecification.java
@@ -1,9 +1,12 @@
 package com.backend.petplace.domain.place.controller;
 
+import com.backend.petplace.domain.place.dto.response.PlaceDetailResponse;
+import com.backend.petplace.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
 
 @Tag(name = "Place", description = "장소 API")
 public interface PlaceSpecification {

--- a/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceSpecification.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "Place", description = "장소 API")
@@ -13,7 +14,8 @@ public interface PlaceSpecification {
 
   @Operation(summary = "장소 상세 조회", description = "장소 ID로 상세 정보를 조회합니다.")
   ResponseEntity<ApiResponse<PlaceDetailResponse>> getPlaceDetail(
-      @Parameter(in = ParameterIn.PATH, description = "장소 ID", required = true) Long placeId
+      @Parameter(in = ParameterIn.PATH, description = "장소 ID", required = true)
+      @Positive Long placeId
   );
 
 }

--- a/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceSpecification.java
@@ -13,7 +13,7 @@ public interface PlaceSpecification {
 
   @Operation(summary = "장소 상세 조회", description = "장소 ID로 상세 정보를 조회합니다.")
   ResponseEntity<ApiResponse<PlaceDetailResponse>> getPlaceDetail(
-      @Parameter(in = ParameterIn.PATH, description = "장소 ID", required = true) Long id
+      @Parameter(in = ParameterIn.PATH, description = "장소 ID", required = true) Long placeId
   );
 
 }

--- a/backend/src/main/java/com/backend/petplace/domain/place/dto/response/PlaceDetailResponse.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/dto/response/PlaceDetailResponse.java
@@ -2,6 +2,7 @@ package com.backend.petplace.domain.place.dto.response;
 
 import com.backend.petplace.domain.place.entity.Category1Type;
 import com.backend.petplace.domain.place.entity.Category2Type;
+import com.backend.petplace.domain.place.entity.Place;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "PlaceDetailResponse", description = "장소 상세 응답 DTO")
@@ -27,4 +28,25 @@ public record PlaceDetailResponse(
     String rawDescription
 ) {
 
+  public static PlaceDetailResponse from(Place place) {
+    return new PlaceDetailResponse(
+        place.getId(),
+        place.getName(),
+        place.getCategory1(),
+        place.getCategory2(),
+        place.getOpeningHours(),
+        place.getClosedDays(),
+        place.getParking(),
+        place.getPetAllowed(),
+        place.getPetRestriction(),
+        place.getTel(),
+        place.getUrl(),
+        place.getPostalCode(),
+        place.getAddress(),
+        place.getLatitude(),
+        place.getLongitude(),
+        place.getAverageRating(),
+        place.getTotalReviewCount(),
+        place.getRawDescription());
+  }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/place/dto/response/PlaceDetailResponse.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/dto/response/PlaceDetailResponse.java
@@ -1,0 +1,30 @@
+package com.backend.petplace.domain.place.dto.response;
+
+import com.backend.petplace.domain.place.entity.Category1Type;
+import com.backend.petplace.domain.place.entity.Category2Type;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "PlaceDetailResponse", description = "장소 상세 응답 DTO")
+public record PlaceDetailResponse(
+    @Schema(description = "장소 ID", example = "123") Long id,
+    @Schema(description = "장소명", example = "행복동물병원") String name,
+    @Schema(description = "대분류") Category1Type category1,
+    @Schema(description = "중분류") Category2Type category2,
+    @Schema(description = "영업시간", example = "월~금 09:00~18:00") String openingHours,
+    @Schema(description = "휴무일", example = "매주 토/일, 공휴일") String closedDays,
+    @Schema(description = "주차 가능") Boolean parking,
+    @Schema(description = "반려동물 동반 가능") Boolean petAllowed,
+    @Schema(description = "반려동물 제한", example = "야외만") String petRestriction,
+    @Schema(description = "전화번호", example = "031-000-0000") String tel,
+    @Schema(description = "웹사이트 URL", example = "https://www.naver.com/~") String url,
+    @Schema(description = "우편번호", example = "06236") String postalCode,
+    @Schema(description = "주소", example = "~시 ~구 ~로 65") String address,
+    @Schema(description = "위도", example = "33.0000000") Double latitude,
+    @Schema(description = "경도", example = "126.000000") Double longitude,
+    @Schema(description = "평균 평점", example = "7") Double averageRating,
+    @Schema(description = "리뷰 수", example = "70") Integer totalReviewCount,
+    @Schema(description = "원본 설명", example = "운영시간:~|휴무일 :~|주차 불가|반려동물 동반가능|반려동물 제한사항 :~")
+    String rawDescription
+) {
+
+}

--- a/backend/src/main/java/com/backend/petplace/domain/place/dto/response/PlaceResponse.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/dto/response/PlaceResponse.java
@@ -1,5 +1,0 @@
-package com.backend.petplace.domain.place.dto.response;
-
-public class PlaceResponse {
-
-}

--- a/backend/src/main/java/com/backend/petplace/domain/place/service/PlaceService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/service/PlaceService.java
@@ -1,10 +1,26 @@
 package com.backend.petplace.domain.place.service;
 
+import com.backend.petplace.domain.place.dto.response.PlaceDetailResponse;
+import com.backend.petplace.domain.place.entity.Place;
+import com.backend.petplace.domain.place.repository.PlaceRepository;
+import com.backend.petplace.global.exception.BusinessException;
+import com.backend.petplace.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class PlaceService {
+
+  private final PlaceRepository placeRepository;
+
+  @Transactional(readOnly = true)
+  public PlaceDetailResponse getPlaceDetail(Long placeId) {
+    Place place = placeRepository.findById(placeId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PLACE));
+
+    return PlaceDetailResponse.from(place);
+  }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #78 

## 📝 변경 사항
### AS-IS
- 장소 데이터를 조회하는 API가 존재하지 않아, 프론트엔드에서 개별 장소 상세 정보를 불러올 수 없었음.

### TO-BE
- GET /api/v1/places/{placeId} API 추가
- PlaceController, PlaceService, PlaceDetailResponse 작성
- 존재하지 않는 ID 요청 시 BusinessException(ErrorCode.NOT_FOUND_PLACE) 예외 처리

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 장소 상세 조회(정상) - db와 데이터 일치
<img width="1484" height="1372" alt="image" src="https://github.com/user-attachments/assets/3cc5018a-2893-4069-b4a4-435d3724842a" />

- 장소 상세 조회(존재하지 않는 장소 Id)
<img width="1462" height="730" alt="image" src="https://github.com/user-attachments/assets/383d6330-e674-4b52-af11-a88b349e9ef0" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 예외 처리(NOT_FOUND_PLACE) 및 응답 구조(ApiResponse<T>)의 일관성을 함께 확인 부탁드립니다.
- Swagger 관련 부분 확인 부탁드립니다.


