### PR TITLE
[Refactor] S3 Presigned URL을 사용하여 리뷰 이미지 업로드 방식 개선

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/point/controller/PointController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/point/controller/PointController.java
@@ -16,6 +16,7 @@ public class PointController implements PointSpecification {
 
   private final PointService pointService;
 
+  @Override
   @GetMapping("/my/points")
   public ResponseEntity<ApiResponse<PointHistoryResponse>> getMyPointHistory() {
 

--- a/backend/src/main/java/com/backend/petplace/domain/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/controller/ReviewController.java
@@ -39,7 +39,7 @@ public class ReviewController implements ReviewSpecification {
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 
-  @PostMapping
+  @PostMapping("/reviews")
   public ResponseEntity<ApiResponse<ReviewCreateResponse>> createReview(
       @Valid @RequestBody ReviewCreateRequest request) {
 

--- a/backend/src/main/java/com/backend/petplace/domain/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/controller/ReviewController.java
@@ -31,6 +31,7 @@ public class ReviewController implements ReviewSpecification {
   /**
    * 리뷰 이미지를 업로드할 Presigned URL을 요청하는 API
    */
+  @Override
   @PostMapping("/presigned-url")
   public ResponseEntity<ApiResponse<PresignedUrlResponse>> getPresignedUrl(
       @RequestParam String filename) {
@@ -39,6 +40,7 @@ public class ReviewController implements ReviewSpecification {
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 
+  @Override
   @PostMapping("/reviews")
   public ResponseEntity<ApiResponse<ReviewCreateResponse>> createReview(
       @Valid @RequestBody ReviewCreateRequest request) {
@@ -51,6 +53,7 @@ public class ReviewController implements ReviewSpecification {
     return ResponseEntity.ok(ApiResponse.create(response));
   }
 
+  @Override
   @GetMapping("/places/{placeId}/reviews")
   public ResponseEntity<ApiResponse<PlaceReviewsResponse>> getReviewsByPlace(
       @PathVariable Long placeId) {
@@ -59,6 +62,7 @@ public class ReviewController implements ReviewSpecification {
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 
+  @Override
   @GetMapping("/my/reviews")
   public ResponseEntity<ApiResponse<List<MyReviewResponse>>> getMyReviews() {
 

--- a/backend/src/main/java/com/backend/petplace/domain/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/controller/ReviewController.java
@@ -3,21 +3,22 @@ package com.backend.petplace.domain.review.controller;
 import com.backend.petplace.domain.review.dto.request.ReviewCreateRequest;
 import com.backend.petplace.domain.review.dto.response.MyReviewResponse;
 import com.backend.petplace.domain.review.dto.response.PlaceReviewsResponse;
+import com.backend.petplace.domain.review.dto.response.PresignedUrlResponse;
 import com.backend.petplace.domain.review.dto.response.ReviewCreateResponse;
 import com.backend.petplace.domain.review.service.ReviewService;
+import com.backend.petplace.domain.review.service.S3Service;
 import com.backend.petplace.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -25,16 +26,28 @@ import org.springframework.web.multipart.MultipartFile;
 public class ReviewController implements ReviewSpecification {
 
   private final ReviewService reviewService;
+  private final S3Service s3Service;
 
-  @PostMapping(value = "/reviews", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  /**
+   * 리뷰 이미지를 업로드할 Presigned URL을 요청하는 API
+   */
+  @PostMapping("/presigned-url")
+  public ResponseEntity<ApiResponse<PresignedUrlResponse>> getPresignedUrl(
+      @RequestParam String filename) {
+
+    PresignedUrlResponse response = s3Service.generatePresignedUrl("reviews", filename);
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
+
+  @PostMapping
   public ResponseEntity<ApiResponse<ReviewCreateResponse>> createReview(
-      @Valid @RequestPart("request") ReviewCreateRequest request,
-      @RequestPart(value = "image", required = false) MultipartFile image) {
+      @Valid @RequestBody ReviewCreateRequest request) {
 
     // TODO: Spring Security 도입 후, 실제 인증된 사용자 정보 넘겨주기
     Long currentUserId = 1L;
 
-    ReviewCreateResponse response = reviewService.createReview(currentUserId, request, image);
+    // ✨ 서비스 호출 시 request 객체만 전달
+    ReviewCreateResponse response = reviewService.createReview(currentUserId, request);
     return ResponseEntity.ok(ApiResponse.create(response));
   }
 

--- a/backend/src/main/java/com/backend/petplace/domain/review/controller/ReviewSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/controller/ReviewSpecification.java
@@ -3,7 +3,9 @@ package com.backend.petplace.domain.review.controller;
 import com.backend.petplace.domain.review.dto.request.ReviewCreateRequest;
 import com.backend.petplace.domain.review.dto.response.MyReviewResponse;
 import com.backend.petplace.domain.review.dto.response.PlaceReviewsResponse;
+import com.backend.petplace.domain.review.dto.response.PresignedUrlResponse;
 import com.backend.petplace.domain.review.dto.response.ReviewCreateResponse;
+import com.backend.petplace.domain.review.service.S3Service;
 import com.backend.petplace.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -16,10 +18,14 @@ import org.springframework.web.multipart.MultipartFile;
 @Tag(name = "Review", description = "리뷰 API")
 public interface ReviewSpecification {
 
-  @Operation(summary = "리뷰 등록", description = "특정 장소에 대한 리뷰를 등록합니다. 내용, 별점은 필수이며 이미지는 선택입니다.")
+  @Operation(summary = "리뷰 이미지 Presigned URL 생성", description = "S3에 직접 이미지를 업로드할 수 있는 Presigned URL을 생성합니다.")
+  ResponseEntity<ApiResponse<PresignedUrlResponse>> getPresignedUrl(
+      @Parameter(description = "업로드할 원본 파일명", required = true) String filename
+  );
+
+  @Operation(summary = "리뷰 등록", description = "특정 장소에 대한 리뷰를 등록합니다. 내용, 별점은 필수이며 이미지는 선택입니다. ✅ Presigned URL로 이미지 업로드 후, 리뷰 정보를 최종 저장합니다.")
   ResponseEntity<ApiResponse<ReviewCreateResponse>> createReview(
-      @Parameter(description = "리뷰 정보 - 장소ID, 내용, 별점", required = true) ReviewCreateRequest request,
-      @Parameter(description = "업로드할 이미지 파일 (선택)") MultipartFile image
+      @Parameter(description = "리뷰 정보 - 장소ID, 내용, 별점, S3 이미지 경로", required = true) ReviewCreateRequest request
   );
 
   @Operation(summary = "장소 리뷰 목록 조회", description = "특정 장소에 등록된 모든 리뷰 목록과 별점 평균, 리뷰 총 개수를 조회합니다.")

--- a/backend/src/main/java/com/backend/petplace/domain/review/controller/ReviewSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/controller/ReviewSpecification.java
@@ -5,7 +5,6 @@ import com.backend.petplace.domain.review.dto.response.MyReviewResponse;
 import com.backend.petplace.domain.review.dto.response.PlaceReviewsResponse;
 import com.backend.petplace.domain.review.dto.response.PresignedUrlResponse;
 import com.backend.petplace.domain.review.dto.response.ReviewCreateResponse;
-import com.backend.petplace.domain.review.service.S3Service;
 import com.backend.petplace.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -13,7 +12,6 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Review", description = "리뷰 API")
 public interface ReviewSpecification {

--- a/backend/src/main/java/com/backend/petplace/domain/review/dto/request/ReviewCreateRequest.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/dto/request/ReviewCreateRequest.java
@@ -24,4 +24,7 @@ public class ReviewCreateRequest {
   @Range(min = 1, max = 5, message = "별점은 1점에서 5점 사이여야 합니다.")
   private int rating;
 
+  @Schema(description = "S3에 업로드된 이미지 파일 경로", example = "reviews/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.jpg")
+  private String s3ImagePath;
+
 }

--- a/backend/src/main/java/com/backend/petplace/domain/review/dto/response/PresignedUrlResponse.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/dto/response/PresignedUrlResponse.java
@@ -1,0 +1,17 @@
+package com.backend.petplace.domain.review.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "Presigned URL 응답 DTO")
+public class PresignedUrlResponse {
+
+  @Schema(description = "클라이언트가 PUT 요청 보낼 URL")
+  private String presignedUrl;
+
+  @Schema(description = "업로드 완료 후 서버에 전달할 S3 파일 경로")
+  private String s3FilePath;
+}

--- a/backend/src/main/java/com/backend/petplace/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/service/ReviewService.java
@@ -38,12 +38,11 @@ public class ReviewService {
   private static final String REVIEW_IMAGE_DIR = "reviews";
 
   @Transactional
-  public ReviewCreateResponse createReview(Long userId, ReviewCreateRequest request,
-      MultipartFile image) {
+  public ReviewCreateResponse createReview(Long userId, ReviewCreateRequest request) {
     User user = findUserById(userId);
     Place place = findPlaceById(request.getPlaceId());
 
-    String imageUrl = uploadImageIfPresent(image);
+    String imageUrl = request.getS3ImagePath();
 
     Review review = Review.createNewReview(user, place, request.getContent(), request.getRating(),
         imageUrl);
@@ -98,10 +97,4 @@ public class ReviewService {
         .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_PLACE));
   }
 
-  private String uploadImageIfPresent(MultipartFile image) {
-    if (image != null && !image.isEmpty()) {
-      return s3Uploader.upload(image, REVIEW_IMAGE_DIR);
-    }
-    return null;
-  }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/review/service/S3Service.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/service/S3Service.java
@@ -1,0 +1,58 @@
+package com.backend.petplace.domain.review.service;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.backend.petplace.domain.review.dto.response.PresignedUrlResponse;
+import java.net.URL;
+import java.util.Date;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+  private final AmazonS3Client amazonS3Client;
+
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucket;
+
+  private static final long PRESIGNED_URL_EXPIRATION_MS = 1000 * 60 * 10;
+
+  /**
+   * S3에 파일을 PUT 방식으로 업로드할 수 있는 Presigned URL 생성
+   */
+  public PresignedUrlResponse generatePresignedUrl(String dirName, String originalFilename) {
+    String uniqueFileName = createUniqueFileName(originalFilename, dirName);
+    Date expiration = new Date(System.currentTimeMillis() + PRESIGNED_URL_EXPIRATION_MS);
+
+    GeneratePresignedUrlRequest generatePresignedUrlRequest =
+        new GeneratePresignedUrlRequest(bucket, uniqueFileName)
+            .withMethod(HttpMethod.PUT)
+            .withExpiration(expiration);
+
+    // 업로드될 파일에 대한 접근 권한 설정
+    generatePresignedUrlRequest.addRequestParameter(
+        Headers.S3_CANNED_ACL,
+        CannedAccessControlList.PublicRead.toString());
+
+    URL presignedUrl = amazonS3Client.generatePresignedUrl(generatePresignedUrlRequest);
+
+    // 클라이언트에게 URL과 함께, 업로드 후 서버에 알려줄 파일 경로도 전달
+    return new PresignedUrlResponse(presignedUrl.toString(), uniqueFileName);
+  }
+
+  private String createUniqueFileName(String originalFilename, String dirName) {
+    String extension = "";
+    if (originalFilename != null && originalFilename.contains(".")) {
+      extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+    }
+    // 디렉토리/UUID.확장자 형식으로 고유 파일명 생성
+    return dirName + "/" + UUID.randomUUID() + extension;
+  }
+}

--- a/backend/src/main/java/com/backend/petplace/domain/review/service/S3Service.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/service/S3Service.java
@@ -36,11 +36,6 @@ public class S3Service {
             .withMethod(HttpMethod.PUT)
             .withExpiration(expiration);
 
-    // 업로드될 파일에 대한 접근 권한 설정
-    generatePresignedUrlRequest.addRequestParameter(
-        Headers.S3_CANNED_ACL,
-        CannedAccessControlList.PublicRead.toString());
-
     URL presignedUrl = amazonS3Client.generatePresignedUrl(generatePresignedUrlRequest);
 
     // 클라이언트에게 URL과 함께, 업로드 후 서버에 알려줄 파일 경로도 전달


### PR DESCRIPTION
## 📌 관련 이슈
- close #74 

## 📝 변경 사항
### ⚙️ AS-IS
- 클라이언트가 리뷰 데이터와 이미지 파일(`MultipartFile`)을 함께 서버로 전송하면, 서버가 직접 해당 파일을 받아서 S3에 업로드하고 반환된 URL을 DB에 저장합니다.
- 이미지 파일 크기가 클 경우, 서버가 직접 파일을 처리하는 과정에서 상당한 메모리 및 CPU 자원을 사용하여 서버 부하가 증가할 수 있습니다.

### ⚙️ TO-BE
**✅ 변경 내용:**
1. 클라이언트가 먼저 서버에 Presigned URL 생성을 요청하는 API (POST` /api/v1/presigned-url`)를 추가했습니다.

2. 서버(S3Service)는 S3 버킷에 파일을 PUT 방식으로 직접 업로드할 수 있는 임시 URL(Presigned URL)과 최종 저장될 S3 파일 경로를 생성하여 클라이언트에 응답합니다.

3. 클라이언트는 발급받은 Presigned URL을 사용하여 S3에 직접 이미지 파일을 업로드합니다.

4. 이미지 업로드 완료 후, 클라이언트는 Presigned URL 요청 시 응답받았던 S3 파일 경로와 나머지 리뷰 데이터(글, 별점 등)를 포함하여 리뷰 최종 저장 API (POST `/api/v1/reviews`)를 호출합니다. (MultipartFile 대신 S3 경로를 JSON body에 담아 전송)

5. 서버는 전달받은 S3 파일 경로를 포함하여 리뷰 데이터를 DB에 저장합니다.

**✅ 문제가 해결된 방식:**

서버는 더 이상 대용량 이미지 파일을 직접 수신하거나 처리하지 않고, 가벼운 URL 생성 및 최종 데이터 저장 역할만 수행하게 되어 서버 부하가 크게 감소했습니다.

실제 파일 업로드의 책임은 클라이언트와 S3가 직접 담당하게 되어 역할 분리가 명확해졌습니다.

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="1568" height="1080" alt="image" src="https://github.com/user-attachments/assets/c0ed485c-3a51-406b-9164-f24ed33e451a" />


 **⬇️ presignedUrl을 PUT하기
 ⬇️ content-type : image/이미지 타입 (jpg, heic 등)**
<img width="1460" height="560" alt="image" src="https://github.com/user-attachments/assets/9e87aed6-2227-4c08-b1d9-2154d0c90996" />


 **⬇️ s3ImagePath 넣기**
<img width="1242" height="1026" alt="image" src="https://github.com/user-attachments/assets/3b07c2ad-e502-4dba-8250-ee47369bcfe0" />



## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
오버라이드 어노테이션 커밋을 따로 빼기 뭐해서 낑겨 넣어봤습니다 :)
이미지 url 유효시간은 10분으로 설정했지만, 굳이 노출될 필요도 없을 것 같아서 url은 스크린샷에서 생략했습니다.
