### PR TITLE
[Refactor] 조회 API 성능 개선 (N+1 문제 및 불필요한 쿼리 제거)

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/point/dto/PointTransaction.java
+++ b/backend/src/main/java/com/backend/petplace/domain/point/dto/PointTransaction.java
@@ -31,14 +31,12 @@ public class PointTransaction {
   @Schema(description = "적립 설명", example = "사진 리뷰 작성")
   private String description;
 
-  public static PointTransaction from(Point point) {
-    PointTransaction transaction = new PointTransaction();
-    transaction.pointId = point.getId();
-    transaction.place = new PlaceInfo(point.getPlace());
-    transaction.hasImage = point.getDescription() == PointDescription.REVIEW_PHOTO;
-    transaction.createdDate = point.getRewardDate();
-    transaction.points = point.getAmount();
-    transaction.description = point.getDescription().getDescription();
-    return transaction;
+  public PointTransaction(Long pointId, Long placeId, String placeName, String placeAddress, PointDescription description, LocalDate rewardDate, Integer amount) {
+    this.pointId = pointId;
+    this.place = new PlaceInfo(placeId, placeName, placeAddress);
+    this.hasImage = description == PointDescription.REVIEW_PHOTO;
+    this.createdDate = rewardDate;
+    this.points = amount;
+    this.description = description.getDescription();
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/point/repository/PointRepository.java
+++ b/backend/src/main/java/com/backend/petplace/domain/point/repository/PointRepository.java
@@ -1,6 +1,7 @@
 package com.backend.petplace.domain.point.repository;
 
 import com.backend.petplace.domain.place.entity.Place;
+import com.backend.petplace.domain.point.dto.PointTransaction;
 import com.backend.petplace.domain.point.entity.Point;
 import com.backend.petplace.domain.review.entity.Review;
 import com.backend.petplace.domain.user.entity.User;
@@ -21,4 +22,12 @@ public interface PointRepository extends JpaRepository<Point, Long> {
   Optional<Point> findByReview(Review review);
 
   List<Point> findByUserOrderByIdDesc(User user);
+
+  @Query("SELECT new com.backend.petplace.domain.point.dto.PointTransaction(" +
+      "p.id, pl.id, pl.name, pl.address, p.description, p.rewardDate, p.amount) " +
+      "FROM Point p " +
+      "JOIN p.place pl " +
+      "WHERE p.user = :user " +
+      "ORDER BY p.id DESC")
+  List<PointTransaction> findPointHistoryByUser(@Param("user") User user);
 }

--- a/backend/src/main/java/com/backend/petplace/domain/point/service/PointService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/point/service/PointService.java
@@ -49,12 +49,7 @@ public class PointService {
   public PointHistoryResponse getPointHistory(Long userId) {
     User user = findUserById(userId);
 
-    List<Point> points = pointRepository.findByUserOrderByIdDesc(user);
-
-    List<PointTransaction> history = points.stream()
-        .map(PointTransaction::from)
-        .toList();
-
+    List<PointTransaction> history = pointRepository.findPointHistoryByUser(user);
     return new PointHistoryResponse(user.getTotalPoint(), history);
   }
 

--- a/backend/src/main/java/com/backend/petplace/domain/review/dto/PlaceInfo.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/dto/PlaceInfo.java
@@ -14,12 +14,12 @@ public class PlaceInfo {
   @Schema(description = "장소 이름", example = "멍멍카페")
   private String placeName;
 
-  @Schema(description = "장소 전체 주소", example = "[06123] 서울 강남구 테헤란로 123")
+  @Schema(description = "장소 전체 주소 -  우편번호 제외", example = "서울 강남구 테헤란로 123")
   private String fullAddress;
 
-  public PlaceInfo(Place place) {
-    this.placeId = place.getId();
-    this.placeName = place.getName();
-    this.fullAddress = String.format("[%s] %s", place.getPostalCode(), place.getAddress());
+  public PlaceInfo(Long placeId, String placeName, String address) {
+    this.placeId = placeId;
+    this.placeName = placeName;
+    this.fullAddress = address;
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/review/dto/ReviewInfo.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/dto/ReviewInfo.java
@@ -3,6 +3,7 @@ package com.backend.petplace.domain.review.dto;
 import com.backend.petplace.domain.review.entity.Review;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -29,14 +30,12 @@ public class ReviewInfo {
   @Schema(description = "작성일", example = "2025-10-15")
   private LocalDate createdDate;
 
-  public static ReviewInfo from(Review review) {
-    ReviewInfo reviewInfo = new ReviewInfo();
-    reviewInfo.reviewId = review.getId();
-    reviewInfo.userName = review.getUser().getNickName();
-    reviewInfo.content = review.getContent();
-    reviewInfo.rating = review.getRating();
-    reviewInfo.imageUrl = review.getImageUrl();
-    reviewInfo.createdDate = review.getCreatedDate().toLocalDate();
-    return reviewInfo;
+  public ReviewInfo(Long reviewId, String userName, String content, int rating, String imageUrl, LocalDateTime createdDate) {
+    this.reviewId = reviewId;
+    this.userName = userName;
+    this.content = content;
+    this.rating = rating;
+    this.imageUrl = imageUrl;
+    this.createdDate = createdDate.toLocalDate();
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/review/dto/response/MyReviewResponse.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/dto/response/MyReviewResponse.java
@@ -41,7 +41,6 @@ public class MyReviewResponse {
     this.content = content;
     this.imageUrl = imageUrl;
     this.createdDate = createdDate.toLocalDate();
-    // ✨ Null 처리 추가: 포인트 내역이 없을 수 있으므로
     this.pointsAwarded = (pointsAwarded != null) ? pointsAwarded : 0;
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/review/dto/response/MyReviewResponse.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/dto/response/MyReviewResponse.java
@@ -4,6 +4,7 @@ import com.backend.petplace.domain.review.dto.PlaceInfo;
 import com.backend.petplace.domain.review.entity.Review;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -33,15 +34,14 @@ public class MyReviewResponse {
   @Schema(description = "해당 리뷰로 적립된 포인트", example = "100")
   private int pointsAwarded;
 
-  public static MyReviewResponse from(Review review, int pointsAwarded) {
-    MyReviewResponse response = new MyReviewResponse();
-    response.reviewId = review.getId();
-    response.place = new PlaceInfo(review.getPlace());
-    response.rating = review.getRating();
-    response.content = review.getContent();
-    response.imageUrl = review.getImageUrl();
-    response.createdDate = review.getCreatedDate().toLocalDate();
-    response.pointsAwarded = pointsAwarded;
-    return response;
+  public MyReviewResponse(Long reviewId, Long placeId, String placeName, String placeAddress, int rating, String content, String imageUrl, LocalDateTime createdDate, Integer pointsAwarded) {
+    this.reviewId = reviewId;
+    this.place = new PlaceInfo(placeId, placeName, placeAddress);
+    this.rating = rating;
+    this.content = content;
+    this.imageUrl = imageUrl;
+    this.createdDate = createdDate.toLocalDate();
+    // ✨ Null 처리 추가: 포인트 내역이 없을 수 있으므로
+    this.pointsAwarded = (pointsAwarded != null) ? pointsAwarded : 0;
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/repository/ReviewRepository.java
@@ -1,6 +1,8 @@
 package com.backend.petplace.domain.review.repository;
 
 import com.backend.petplace.domain.place.entity.Place;
+import com.backend.petplace.domain.review.dto.ReviewInfo;
+import com.backend.petplace.domain.review.dto.response.MyReviewResponse;
 import com.backend.petplace.domain.review.entity.Review;
 import com.backend.petplace.domain.user.entity.User;
 import java.util.List;
@@ -14,7 +16,25 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
   List<Review> findByPlaceOrderByIdDesc(Place place);
 
-  @Query("select r from Review r join fetch r.place p where r.user = :user order by r.createdDate desc") //N+1 문제 해소, 최신순으로 정렬
+  @Query("select r from Review r join fetch r.place p where r.user = :user order by r.createdDate desc")
+    //N+1 문제 해소, 최신순으로 정렬
   List<Review> findByUserWithPlace(@Param("user") User user);
+
+  @Query("SELECT new com.backend.petplace.domain.review.dto.MyReviewResponse(" +
+      "r.id, p.id, p.name, p.address, r.rating, r.content, r.imageUrl, r.createdDate, pt.amount) " +
+      "FROM Review r " +
+      "JOIN r.place p " + // Place 정보 JOIN
+      "LEFT JOIN Point pt ON pt.review = r " + // Point 정보 LEFT JOIN (포인트 없을 수도 있음)
+      "WHERE r.user = :user ORDER BY r.id DESC")
+  List<MyReviewResponse> findMyReviews(@Param("user") User user);
+
+  @Query("SELECT new com.backend.petplace.domain.review.dto.ReviewInfo(" +
+      "r.id, r.user.nickName, r.content, r.rating, r.imageUrl, r.createdDate) " +
+      "FROM Review r " +
+      // User 정보는 Review 엔티티에 연관관계가 있으므로 JOIN FETCH 또는 DTO에서 직접 User ID 조회 방식 선택 가능
+      // 여기서는 간단하게 r.user.nickName 사용 (쿼리는 늘지만 N+1은 아님)
+      // 만약 User 정보가 더 많이 필요하면 JOIN FETCH r.user 추가 고려
+      "WHERE r.place = :place ORDER BY r.id DESC")
+  List<ReviewInfo> findReviewInfosByPlace(@Param("place") Place place);
 
 }

--- a/backend/src/main/java/com/backend/petplace/domain/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/repository/ReviewRepository.java
@@ -20,7 +20,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     //N+1 문제 해소, 최신순으로 정렬
   List<Review> findByUserWithPlace(@Param("user") User user);
 
-  @Query("SELECT new com.backend.petplace.domain.review.dto.MyReviewResponse(" +
+  @Query("SELECT new com.backend.petplace.domain.review.dto.response.MyReviewResponse(" +
       "r.id, p.id, p.name, p.address, r.rating, r.content, r.imageUrl, r.createdDate, pt.amount) " +
       "FROM Review r " +
       "JOIN r.place p " + // Place 정보 JOIN

--- a/backend/src/main/java/com/backend/petplace/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/service/ReviewService.java
@@ -2,7 +2,6 @@ package com.backend.petplace.domain.review.service;
 
 import com.backend.petplace.domain.place.entity.Place;
 import com.backend.petplace.domain.place.repository.PlaceRepository;
-import com.backend.petplace.domain.point.entity.Point;
 import com.backend.petplace.domain.point.repository.PointRepository;
 import com.backend.petplace.domain.point.service.PointService;
 import com.backend.petplace.domain.point.type.PointAddResult;
@@ -22,7 +21,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -58,19 +56,10 @@ public class ReviewService {
 
   @Transactional(readOnly = true)
   public List<MyReviewResponse> getMyReviews(Long currentUserId) {
+
     User user = findUserById(currentUserId);
 
-    List<Review> reviews = reviewRepository.findByUserOrderByIdDesc(user);
-
-    return reviews.stream()
-        .map(review -> {
-          int points = pointRepository.findByReview(review)
-              .map(Point::getAmount)
-              .orElse(0);
-
-          return MyReviewResponse.from(review, points);
-        })
-        .toList();
+    return reviewRepository.findMyReviews(user);
   }
 
   @Transactional(readOnly = true)
@@ -78,12 +67,7 @@ public class ReviewService {
 
     Place place = findPlaceById(placeId);
 
-    List<Review> reviews = reviewRepository.findByPlaceOrderByIdDesc(place);
-
-    List<ReviewInfo> reviewInfos = reviews.stream()
-        .map(ReviewInfo::from)
-        .toList();
-
+    List<ReviewInfo> reviewInfos = reviewRepository.findReviewInfosByPlace(place);
     return new PlaceReviewsResponse(place, reviewInfos);
   }
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #81 

## 📝 변경 사항
### AS-IS
- 조회 API (`/my/reviews`, `/places/{placeId}/reviews`, `/my/points`) 실행 시, 목록 조회 후 각 항목의 연관 엔티티(Place, User, Point)를 조회하기 위해 N+1 쿼리가 발생했습니다.
- 엔티티 전체를 조회하여 불필요한 컬럼까지 조회하는 비효율이 있었습니다.

### TO-BE
- JPA Repository에 **DTO 프로젝션(생성자 표현식)**을 사용하는 JPQL 쿼리를 추가했습니다 (`SELECT new ...`).
- 이를 통해 데이터베이스에서 처음부터 필요한 컬럼만 조회하여 DTO 형태로 직접 반환하도록 변경했습니다.
- Service 계층의 조회 로직에서 DTO 변환 코드(`stream().map(...)`)를 제거하고, Repository의 DTO 조회 메서드를 사용하도록 단순화했습니다.

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트


## 기대 효과
- 각 조회 API 호출 시 발생하는 DB 쿼리 수가 N+1에서 **1~2개로 대폭 감소**하여 성능이 크게 향상됩니다.

> ✅ 리팩토링 후 (DTO 프로젝션):
> 
> `SELECT * FROM users WHERE user_id = ?` (사용자 조회: 1번)
> 
> `SELECT r.id, p.id, p.name, ... FROM review r JOIN place p ... LEFT JOIN point pt ... WHERE r.user_id = ?` (리뷰 DTO 목록 조회: 1번)
> 
> 총 쿼리 수 = 1 + 1 = 2번

- 불필요한 컬럼 조회가 사라져 네트워크 및 메모리 사용량이 감소합니다.
- Service 계층의 코드가 단순화되고, Repository의 역할(데이터 조회)이 더 명확해집니다.

## 📸 스크린샷
- 사용자 리뷰 조회 시 2번의 조회만 나타남
<img width="323" height="381" alt="image" src="https://github.com/user-attachments/assets/fc3d6a88-9583-4853-a184-d1bd543f9f3d" />

<img width="1255" height="671" alt="image" src="https://github.com/user-attachments/assets/e6c8eb6c-5075-48a2-a247-4f866b1ce3a9" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
멘토님께서 피드백 주신 부분, 창중님이 사용하신 페치 조인, dto 프로젝션 3가지 방법에 대해 고민하다 저희는 이미 dto를 생성하여 사용하고 있고, 창중님께서는 페치 조인을 사용하셨기에 다른 방법을 다뤄보는 것도 좋을 것 같아서 이 방법으로 개선하였습니다.
더 상세한 고민 사항이나 아쉬운 점 등은 [노션](https://www.notion.so/2929d0051b998025a283ea951608254d?source=copy_link)에 정리해뒀습니다 :)



