### PR TITLE
[Refactor] 리뷰 및 포인트 관련 로직 재구조화

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/point/controller/PointSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/point/controller/PointSpecification.java
@@ -1,6 +1,9 @@
 package com.backend.petplace.domain.point.controller;
 
+import static com.backend.petplace.global.response.ErrorCode.NOT_FOUND_MEMBER;
+
 import com.backend.petplace.domain.point.dto.response.PointHistoryResponse;
+import com.backend.petplace.global.config.swagger.ApiErrorCodeExamples;
 import com.backend.petplace.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -9,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 @Tag(name = "Point", description = "포인트 관련 API")
 public interface PointSpecification {
 
+  @ApiErrorCodeExamples({NOT_FOUND_MEMBER})
   @Operation(summary = "내 포인트 내역 조회", description = "현재 로그인한 사용자의 총 보유 포인트와 포인트 적립 내역을 조회합니다.")
   ResponseEntity<ApiResponse<PointHistoryResponse>> getMyPointHistory();
 }

--- a/backend/src/main/java/com/backend/petplace/domain/point/dto/PlaceInfo.java
+++ b/backend/src/main/java/com/backend/petplace/domain/point/dto/PlaceInfo.java
@@ -1,6 +1,5 @@
-package com.backend.petplace.domain.review.dto;
+package com.backend.petplace.domain.point.dto;
 
-import com.backend.petplace.domain.place.entity.Place;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 

--- a/backend/src/main/java/com/backend/petplace/domain/point/dto/PointTransaction.java
+++ b/backend/src/main/java/com/backend/petplace/domain/point/dto/PointTransaction.java
@@ -1,8 +1,6 @@
 package com.backend.petplace.domain.point.dto;
 
-import com.backend.petplace.domain.point.entity.Point;
 import com.backend.petplace.domain.point.entity.PointDescription;
-import com.backend.petplace.domain.review.dto.PlaceInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import lombok.Getter;

--- a/backend/src/main/java/com/backend/petplace/domain/point/entity/Point.java
+++ b/backend/src/main/java/com/backend/petplace/domain/point/entity/Point.java
@@ -1,6 +1,7 @@
 package com.backend.petplace.domain.point.entity;
 
 import com.backend.petplace.domain.place.entity.Place;
+import com.backend.petplace.domain.point.type.PointPolicy;
 import com.backend.petplace.domain.review.entity.Review;
 import com.backend.petplace.domain.user.entity.User;
 import com.backend.petplace.global.entity.BaseEntity;
@@ -61,7 +62,7 @@ public class Point extends BaseEntity {
   private LocalDate rewardDate;
 
   @Builder
-  public Point(Long id, User user, Place place, Review review, Integer amount,
+  private Point(Long id, User user, Place place, Review review, Integer amount,
       PointDescription description, LocalDate rewardDate) {
     this.id = id;
     this.user = user;
@@ -72,13 +73,10 @@ public class Point extends BaseEntity {
     this.rewardDate = rewardDate;
   }
 
-  private static final int POINTS_FOR_PHOTO_REVIEW = 100;
-  private static final int POINTS_FOR_TEXT_REVIEW = 50;
-
   public static Point createFromReview(Review review) {
     boolean hasImage = (review.getImageUrl() != null && !review.getImageUrl().isBlank());
 
-    int amount = hasImage ? POINTS_FOR_PHOTO_REVIEW : POINTS_FOR_TEXT_REVIEW;
+    int amount = hasImage ? PointPolicy.REVIEW_PHOTO_POINTS.getValue() : PointPolicy.REVIEW_TEXT_POINTS.getValue();
     PointDescription description =
         hasImage ? PointDescription.REVIEW_PHOTO : PointDescription.REVIEW_TEXT;
 

--- a/backend/src/main/java/com/backend/petplace/domain/point/service/PointService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/point/service/PointService.java
@@ -5,6 +5,7 @@ import com.backend.petplace.domain.point.dto.response.PointHistoryResponse;
 import com.backend.petplace.domain.point.entity.Point;
 import com.backend.petplace.domain.point.repository.PointRepository;
 import com.backend.petplace.domain.point.type.PointAddResult;
+import com.backend.petplace.domain.point.type.PointPolicy;
 import com.backend.petplace.domain.review.entity.Review;
 import com.backend.petplace.domain.user.entity.User;
 import com.backend.petplace.domain.user.repository.UserRepository;
@@ -23,8 +24,6 @@ public class PointService {
   private final PointRepository pointRepository;
   private final UserRepository userRepository;
 
-  private static final int DAILY_POINT_LIMIT = 1000;
-
   @Transactional
   public PointAddResult addPointsForReview(User user, Review review) {
     LocalDate today = LocalDate.now();
@@ -34,7 +33,8 @@ public class PointService {
     }
 
     Integer todaysPoints = pointRepository.findTodaysPointsSumByUser(user, today);
-    if (todaysPoints >= DAILY_POINT_LIMIT) {
+
+    if (todaysPoints >= PointPolicy.DAILY_LIMIT.getValue()) {
       return PointAddResult.DAILY_LIMIT_EXCEEDED;
     }
 

--- a/backend/src/main/java/com/backend/petplace/domain/point/type/PointPolicy.java
+++ b/backend/src/main/java/com/backend/petplace/domain/point/type/PointPolicy.java
@@ -1,0 +1,17 @@
+package com.backend.petplace.domain.point.type;
+
+import lombok.Getter;
+
+@Getter
+public enum PointPolicy {
+
+  DAILY_LIMIT(1000),
+  REVIEW_PHOTO_POINTS(100),
+  REVIEW_TEXT_POINTS(50);
+
+  private final int value;
+
+  PointPolicy(int value) {
+    this.value = value;
+  }
+}

--- a/backend/src/main/java/com/backend/petplace/domain/review/controller/ReviewSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/controller/ReviewSpecification.java
@@ -1,10 +1,14 @@
 package com.backend.petplace.domain.review.controller;
 
+import static com.backend.petplace.global.response.ErrorCode.NOT_FOUND_MEMBER;
+import static com.backend.petplace.global.response.ErrorCode.NOT_FOUND_PLACE;
+
 import com.backend.petplace.domain.review.dto.request.ReviewCreateRequest;
 import com.backend.petplace.domain.review.dto.response.MyReviewResponse;
 import com.backend.petplace.domain.review.dto.response.PlaceReviewsResponse;
 import com.backend.petplace.domain.review.dto.response.PresignedUrlResponse;
 import com.backend.petplace.domain.review.dto.response.ReviewCreateResponse;
+import com.backend.petplace.global.config.swagger.ApiErrorCodeExamples;
 import com.backend.petplace.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -21,16 +25,19 @@ public interface ReviewSpecification {
       @Parameter(description = "업로드할 원본 파일명", required = true) String filename
   );
 
+  @ApiErrorCodeExamples({NOT_FOUND_MEMBER, NOT_FOUND_PLACE})
   @Operation(summary = "리뷰 등록", description = "특정 장소에 대한 리뷰를 등록합니다. 내용, 별점은 필수이며 이미지는 선택입니다. ✅ Presigned URL로 이미지 업로드 후, 리뷰 정보를 최종 저장합니다.")
   ResponseEntity<ApiResponse<ReviewCreateResponse>> createReview(
       @Parameter(description = "리뷰 정보 - 장소ID, 내용, 별점, S3 이미지 경로", required = true) ReviewCreateRequest request
   );
 
+  @ApiErrorCodeExamples({NOT_FOUND_PLACE})
   @Operation(summary = "장소 리뷰 목록 조회", description = "특정 장소에 등록된 모든 리뷰 목록과 별점 평균, 리뷰 총 개수를 조회합니다.")
   ResponseEntity<ApiResponse<PlaceReviewsResponse>> getReviewsByPlace(
       @Parameter(in = ParameterIn.PATH, description = "장소 ID", required = true) Long placeId
   );
 
+  @ApiErrorCodeExamples({NOT_FOUND_MEMBER})
   @Operation(summary = "내 리뷰 목록 조회", description = "현재 로그인한 사용자가 작성한 모든 리뷰 목록을 조회합니다.")
   ResponseEntity<ApiResponse<List<MyReviewResponse>>> getMyReviews();
 }

--- a/backend/src/main/java/com/backend/petplace/domain/review/dto/response/MyReviewResponse.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/dto/response/MyReviewResponse.java
@@ -1,7 +1,6 @@
 package com.backend.petplace.domain.review.dto.response;
 
-import com.backend.petplace.domain.review.dto.PlaceInfo;
-import com.backend.petplace.domain.review.entity.Review;
+import com.backend.petplace.domain.point.dto.PlaceInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/backend/src/main/java/com/backend/petplace/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/service/ReviewService.java
@@ -2,7 +2,6 @@ package com.backend.petplace.domain.review.service;
 
 import com.backend.petplace.domain.place.entity.Place;
 import com.backend.petplace.domain.place.repository.PlaceRepository;
-import com.backend.petplace.domain.point.repository.PointRepository;
 import com.backend.petplace.domain.point.service.PointService;
 import com.backend.petplace.domain.point.type.PointAddResult;
 import com.backend.petplace.domain.review.dto.ReviewInfo;
@@ -16,7 +15,6 @@ import com.backend.petplace.domain.user.entity.User;
 import com.backend.petplace.domain.user.repository.UserRepository;
 import com.backend.petplace.global.exception.BusinessException;
 import com.backend.petplace.global.response.ErrorCode;
-import com.backend.petplace.global.s3.S3Uploader;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,13 +25,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReviewService {
 
   private final PointService pointService;
-  private final PointRepository pointRepository;
   private final ReviewRepository reviewRepository;
   private final UserRepository userRepository;
   private final PlaceRepository placeRepository;
-  private final S3Uploader s3Uploader;
-
-  private static final String REVIEW_IMAGE_DIR = "reviews";
 
   @Transactional
   public ReviewCreateResponse createReview(Long userId, ReviewCreateRequest request) {


### PR DESCRIPTION
## 📌 관련 이슈
- close #85 

## 📝 변경 사항
### AS-IS
- 스웨거에 예외처리 시 결과 표시 부재
- PlaceInfo dto의 위치가 부적절한 도메인에 위치

✅ 포인트 정책
- 포인트 정책 값(일일 한도, 리뷰 포인트 등)이 `PointService` 및 `Point` 엔티티 내부에 `static final int` 상수로 하드코딩되어 있었습니다.
- 정책 변경 시 여러 파일을 수정해야 하고, 관련 정책 값들이 분산되어 있어 관리가 어려웠습니다.

### TO-BE
- `@ApiErrorCodeExamples` 를 추가하여 예외처리 결과 표시
- PlaceInfo dto의 사용 용도에 맞게 point 도메인으로 위치 변경

✅ 포인트 정책
- `PointPolicy` Enum을 새로 생성하여 모든 포인트 정책 값을 중앙에서 관리하도록 변경했습니다.
- `PointService`와 `Point` 엔티티에서 기존 상수를 제거하고, `PointPolicy` Enum 값을 참조하여 사용하도록 수정했습니다.


## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 스웨거 예외처리된 화면
<img width="1404" height="582" alt="image" src="https://github.com/user-attachments/assets/7747406a-a5be-44fe-9d31-3289d92ec29f" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
생각해보니 포인트 정책은 어쨌든 포인트와 연관된 작업이라 global이 아닌 domain 패키지에 넣었습니다 !
그리고 스웨거에 오류를 추가하는 부분을 제가 처음에 놓쳐서 다들 놓치셨을 것 같은데 참고 부탁드립니다 :)

