### PR TITLE
refactor : 안전하게 userId 받아오기

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderController.java
@@ -3,11 +3,15 @@ package com.backend.petplace.domain.order.controller;
 import com.backend.petplace.domain.order.dto.request.OrderCreateRequest;
 import com.backend.petplace.domain.order.dto.response.OrderReadByIdResponse;
 import com.backend.petplace.domain.order.service.OrderService;
+import com.backend.petplace.global.exception.BusinessException;
+import com.backend.petplace.global.jwt.CustomUserDetails;
 import com.backend.petplace.global.response.ApiResponse;
+import com.backend.petplace.global.response.ErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,38 +21,44 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("api/v1")
+@RequestMapping("api/v1/orders")
 @RequiredArgsConstructor
 public class OrderController implements OrderSpecification {
 
   private final OrderService orderService;
 
   @Override
-  @PostMapping(value = "/orders")
+  @PostMapping()
   public ResponseEntity<ApiResponse<Void>> createOrder(
-      @RequestBody OrderCreateRequest request,
-      @CookieValue("userId") Long userId) {
+      @RequestBody OrderCreateRequest request) {
 
-    orderService.createOrder(request, userId);
+    orderService.createOrder(request, getUserIdFromJWTToken());
     return ResponseEntity.ok(ApiResponse.success());
   }
 
   @Override
-  @GetMapping(value = "/orders")
-  public ResponseEntity<ApiResponse<List<OrderReadByIdResponse>>> getOrderById(
-      @CookieValue("userId") Long userId) {
+  @GetMapping()
+  public ResponseEntity<ApiResponse<List<OrderReadByIdResponse>>> getOrderById() {
 
-    List<OrderReadByIdResponse> responses = orderService.getOrdersByUserId(userId);
+    List<OrderReadByIdResponse> responses = orderService.getOrdersByUserId(getUserIdFromJWTToken());
     return ResponseEntity.ok(ApiResponse.success(responses));
   }
 
   @Override
-  @PatchMapping("/orders/{orderid}/cancel")
-  public ResponseEntity<ApiResponse<Void>> cancelOrder(
-      @PathVariable("orderid") Long orderId,
-      @CookieValue("userId") Long userId) {
+  @PatchMapping("/{orderid}/cancel")
+  public ResponseEntity<ApiResponse<Void>> cancelOrder(@PathVariable("orderid") Long orderId) {
 
-    orderService.cancelOrder(userId, orderId);
+    orderService.cancelOrder(getUserIdFromJWTToken(), orderId);
     return ResponseEntity.ok(ApiResponse.success());
+  }
+
+  private Long getUserIdFromJWTToken() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null ||
+        !(authentication.getPrincipal() instanceof CustomUserDetails)) {
+      throw new BusinessException(ErrorCode.NOT_FOUND_MEMBER);
+    }
+    CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+    return userDetails.getUserId();
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderSpecification.java
@@ -2,6 +2,7 @@ package com.backend.petplace.domain.order.controller;
 
 import com.backend.petplace.domain.order.dto.request.OrderCreateRequest;
 import com.backend.petplace.domain.order.dto.response.OrderReadByIdResponse;
+import com.backend.petplace.global.jwt.CustomUserDetails;
 import com.backend.petplace.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -12,13 +13,16 @@ public interface OrderSpecification {
 
   @Operation(summary = "주문 생성", description = "새로운 주문을 생성합니다.")
   ResponseEntity<ApiResponse<Void>> createOrder(
-      @Parameter(description = "가격 총액, 주문객체 리스트") OrderCreateRequest request);
+      @Parameter(description = "가격 총액, 주문객체 리스트") OrderCreateRequest request,
+      @Parameter(description = "JWT토큰에서 받은 유저 정보") CustomUserDetails userDetails);
 
   @Operation(summary = "사용자 주문 조회", description = "특정 사용자의 모든 주문을 조회합니다.")
-  ResponseEntity<ApiResponse<List<OrderReadByIdResponse>>> getOrderById();
+  ResponseEntity<ApiResponse<List<OrderReadByIdResponse>>> getOrderById(
+      @Parameter(description = "JWT토큰에서 받은 유저 정보") CustomUserDetails userDetails);
 
   @Operation(summary = "주문 취소", description = "특정 주문을 취소 상태로 업데이트합니다.")
   ResponseEntity<ApiResponse<Void>> cancelOrder(
-      @Parameter(description = "요청에서 받은 주문 아이디") Long orderId);
+      @Parameter(description = "요청에서 받은 주문 아이디") Long orderId,
+      @Parameter(description = "JWT토큰에서 받은 유저 정보") CustomUserDetails userDetails);
 
 }

--- a/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderSpecification.java
@@ -12,16 +12,13 @@ public interface OrderSpecification {
 
   @Operation(summary = "주문 생성", description = "새로운 주문을 생성합니다.")
   ResponseEntity<ApiResponse<Void>> createOrder(
-      @Parameter(description = "가격 총액, 주문객체 리스트") OrderCreateRequest request,
-      @Parameter(description = "쿠키에서 받은 유저의 아이디") Long userId);
+      @Parameter(description = "가격 총액, 주문객체 리스트") OrderCreateRequest request);
 
   @Operation(summary = "사용자 주문 조회", description = "특정 사용자의 모든 주문을 조회합니다.")
-  ResponseEntity<ApiResponse<List<OrderReadByIdResponse>>> getOrderById(
-      @Parameter(description = "쿠키에서 받은 유저의 아이디") Long userId);
+  ResponseEntity<ApiResponse<List<OrderReadByIdResponse>>> getOrderById();
 
   @Operation(summary = "주문 취소", description = "특정 주문을 취소 상태로 업데이트합니다.")
   ResponseEntity<ApiResponse<Void>> cancelOrder(
-      @Parameter(description = "요청에서 받은 주문 아이디") Long orderId,
-      @Parameter(description = "쿠키에서 받은 유저의 아이디") Long userId);
+      @Parameter(description = "요청에서 받은 주문 아이디") Long orderId);
 
 }


### PR DESCRIPTION
- authentication.getPrincipal()로 받아왔습니다.
- 위에 따라 parameter가 바뀌어서 swagger interface도 고쳤습니다.
- rest api 경로도 @RequestMapping("api/v1") 에서 @RequestMapping("api/v1/orders")로 고쳤습니다.

## 📌 관련 이슈
- close #90

## 📝 변경 사항
### AS-IS
- 기존 코드의 동작 방식 설명
- 기존의 문제점 설명
- 1. 쿠키에서 userId를 받아온다.
- 2. 저번 피드백 때 rest api 경로 고치기를 빼먹었다.
<br></br>

### TO-BE
- 변경된 내용 설명
- 문제가 해결된 방식 설명
- 1.  authentication.getPrincipal()로 받아온다.
- 1 - 2. 위에 따라 parameter가 바뀌어서 swagger interface도 고쳤다.
- 2. rest api 경로도 @RequestMapping("api/v1") 에서 @RequestMapping("api/v1/orders")로 고쳤다.
<br></br>

## 🔍 테스트
- [ ] 테스트 코드 작성
- [X] API 테스트
- [ ] 로컬 테스트
<br></br>

## 📸 스크린샷
- 주문 생성 요청 전. 쿠키 없음.
<img width="1414" height="970" alt="주문 생성 요청 전  쿠키 없음" src="https://github.com/user-attachments/assets/d8a0059d-7b1c-4b01-9ca2-ad1675ad6c5c" />

<br></br>

- 주문 생성 요청 전. DB 상태. user의 포인트: 10
<img width="1406" height="968" alt="주문 생성 요청 전" src="https://github.com/user-attachments/assets/b4001295-d88e-4a0f-931b-c48fbc25fd89" />

<br></br>

- 주문 생성 요청 후. 성공. user의 포인트: 10 - 2 = 8
<img width="1378" height="936" alt="주문 생성 요청 후  성공" src="https://github.com/user-attachments/assets/285d8ac2-1fcd-4051-a353-7004f7e71b9f" />

<br></br>

- 주문 읽기 요청 후. 성공.
<img width="484" height="959" alt="주문 읽기 요청 후" src="https://github.com/user-attachments/assets/709bf8c2-654f-434d-8c8e-76d4b4f97d44" />

<br></br>

- 주문 취소 요청 전.
<img width="1144" height="1056" alt="주문 취소 요청 전" src="https://github.com/user-attachments/assets/8bb91ff8-b4f2-45c5-aed1-eff8f718d3f8" />

<br></br>

- 주문 취소 요청 후. 성공.
<img width="1158" height="972" alt="주문 취소 요청 후" src="https://github.com/user-attachments/assets/11b1fc13-973b-4f60-84d3-6348ae8bb813" />

<br></br>

## ✅ 체크리스트
- [X] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [X] 코딩 컨벤션을 준수했나요?
- [X] 불필요한 코드는 제거했나요?
- [X] 주석은 충분히 작성했나요?
- [X] 테스트는 완료했나요?
<br></br>
## 🙋‍♂️ 리뷰어에게
피드백 환영합니다.

<br></br>
