### PR TITLE
[Feature] 리뷰와 포인트 기능에 회원 인증 로직 추가

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/point/controller/PointController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/point/controller/PointController.java
@@ -2,9 +2,11 @@ package com.backend.petplace.domain.point.controller;
 
 import com.backend.petplace.domain.point.dto.response.PointHistoryResponse;
 import com.backend.petplace.domain.point.service.PointService;
+import com.backend.petplace.global.jwt.CustomUserDetails;
 import com.backend.petplace.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,10 +20,10 @@ public class PointController implements PointSpecification {
 
   @Override
   @GetMapping("/my/points")
-  public ResponseEntity<ApiResponse<PointHistoryResponse>> getMyPointHistory() {
+  public ResponseEntity<ApiResponse<PointHistoryResponse>> getMyPointHistory(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-    // TODO: Spring Security 도입 후, 실제 인증된 사용자 정보 넘겨주기
-    Long currentUserId = 1L;
+    Long currentUserId = userDetails.getUserId();
 
     PointHistoryResponse response = pointService.getPointHistory(currentUserId);
     return ResponseEntity.ok(ApiResponse.success(response));

--- a/backend/src/main/java/com/backend/petplace/domain/point/controller/PointSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/point/controller/PointSpecification.java
@@ -4,6 +4,7 @@ import static com.backend.petplace.global.response.ErrorCode.NOT_FOUND_MEMBER;
 
 import com.backend.petplace.domain.point.dto.response.PointHistoryResponse;
 import com.backend.petplace.global.config.swagger.ApiErrorCodeExamples;
+import com.backend.petplace.global.jwt.CustomUserDetails;
 import com.backend.petplace.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,5 +15,6 @@ public interface PointSpecification {
 
   @ApiErrorCodeExamples({NOT_FOUND_MEMBER})
   @Operation(summary = "내 포인트 내역 조회", description = "현재 로그인한 사용자의 총 보유 포인트와 포인트 적립 내역을 조회합니다.")
-  ResponseEntity<ApiResponse<PointHistoryResponse>> getMyPointHistory();
+  ResponseEntity<ApiResponse<PointHistoryResponse>> getMyPointHistory(
+      CustomUserDetails userDetails);
 }

--- a/backend/src/main/java/com/backend/petplace/domain/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/controller/ReviewController.java
@@ -7,11 +7,13 @@ import com.backend.petplace.domain.review.dto.response.PresignedUrlResponse;
 import com.backend.petplace.domain.review.dto.response.ReviewCreateResponse;
 import com.backend.petplace.domain.review.service.ReviewService;
 import com.backend.petplace.domain.review.service.S3Service;
+import com.backend.petplace.global.jwt.CustomUserDetails;
 import com.backend.petplace.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,12 +45,11 @@ public class ReviewController implements ReviewSpecification {
   @Override
   @PostMapping("/reviews")
   public ResponseEntity<ApiResponse<ReviewCreateResponse>> createReview(
-      @Valid @RequestBody ReviewCreateRequest request) {
+      @Valid @RequestBody ReviewCreateRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-    // TODO: Spring Security 도입 후, 실제 인증된 사용자 정보 넘겨주기
-    Long currentUserId = 1L;
+    Long currentUserId = userDetails.getUserId();
 
-    // ✨ 서비스 호출 시 request 객체만 전달
     ReviewCreateResponse response = reviewService.createReview(currentUserId, request);
     return ResponseEntity.ok(ApiResponse.create(response));
   }
@@ -64,10 +65,10 @@ public class ReviewController implements ReviewSpecification {
 
   @Override
   @GetMapping("/my/reviews")
-  public ResponseEntity<ApiResponse<List<MyReviewResponse>>> getMyReviews() {
+  public ResponseEntity<ApiResponse<List<MyReviewResponse>>> getMyReviews(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-    // TODO: Spring Security 도입 후, 실제 인증된 사용자 정보 넘겨주기
-    Long currentUserId = 1L;
+    Long currentUserId = userDetails.getUserId();
 
     List<MyReviewResponse> myReviews = reviewService.getMyReviews(currentUserId);
     return ResponseEntity.ok(ApiResponse.success(myReviews));

--- a/backend/src/main/java/com/backend/petplace/domain/review/controller/ReviewSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/controller/ReviewSpecification.java
@@ -9,6 +9,7 @@ import com.backend.petplace.domain.review.dto.response.PlaceReviewsResponse;
 import com.backend.petplace.domain.review.dto.response.PresignedUrlResponse;
 import com.backend.petplace.domain.review.dto.response.ReviewCreateResponse;
 import com.backend.petplace.global.config.swagger.ApiErrorCodeExamples;
+import com.backend.petplace.global.jwt.CustomUserDetails;
 import com.backend.petplace.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -28,7 +29,8 @@ public interface ReviewSpecification {
   @ApiErrorCodeExamples({NOT_FOUND_MEMBER, NOT_FOUND_PLACE})
   @Operation(summary = "리뷰 등록", description = "특정 장소에 대한 리뷰를 등록합니다. 내용, 별점은 필수이며 이미지는 선택입니다. ✅ Presigned URL로 이미지 업로드 후, 리뷰 정보를 최종 저장합니다.")
   ResponseEntity<ApiResponse<ReviewCreateResponse>> createReview(
-      @Parameter(description = "리뷰 정보 - 장소ID, 내용, 별점, S3 이미지 경로", required = true) ReviewCreateRequest request
+      @Parameter(description = "리뷰 정보 - 장소ID, 내용, 별점, S3 이미지 경로", required = true) ReviewCreateRequest request,
+      CustomUserDetails userDetails
   );
 
   @ApiErrorCodeExamples({NOT_FOUND_PLACE})
@@ -39,5 +41,5 @@ public interface ReviewSpecification {
 
   @ApiErrorCodeExamples({NOT_FOUND_MEMBER})
   @Operation(summary = "내 리뷰 목록 조회", description = "현재 로그인한 사용자가 작성한 모든 리뷰 목록을 조회합니다.")
-  ResponseEntity<ApiResponse<List<MyReviewResponse>>> getMyReviews();
+  ResponseEntity<ApiResponse<List<MyReviewResponse>>> getMyReviews(CustomUserDetails userDetails);
 }

--- a/backend/src/main/java/com/backend/petplace/global/config/security/SecurityConfig.java
+++ b/backend/src/main/java/com/backend/petplace/global/config/security/SecurityConfig.java
@@ -37,6 +37,8 @@ public class SecurityConfig {
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/h2-console/**").permitAll()
             .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+            .requestMatchers("/api/v1/signup", "/api/v1/login").permitAll() // 회원가입, 로그인
+            .requestMatchers("/api/v1/places/{placeId}/reviews").permitAll() // 장소별 리뷰 조회
             .requestMatchers("/api/v1/**").permitAll()
             .anyRequest().authenticated()
         );


### PR DESCRIPTION
## 📌 관련 이슈
- close #91 

## 📝 변경 사항
### AS-IS
- 리뷰 및 포인트 관련 API (`createReview`, `getMyReviews`, `getMyPointHistory`)에서 사용자 ID를 임시 값(`1L`)으로 하드코딩하여 사용했습니다.
- 로그인 기능 구현 후에도 실제 사용자 인증 정보가 적용되지 않아 보안이 취약했습니다.

### TO-BE
- `ReviewController`와 `PointController`에 `SecurityContextHolder`를 사용하여 현재 인증된 사용자의 ID를 가져오는 로직을 추가했습니다.
- 서비스 메서드 호출 시 하드코딩된 ID 대신 실제 사용자 ID를 전달하도록 수정했습니다.

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="737" height="513" alt="image" src="https://github.com/user-attachments/assets/f1da1cdc-f847-40c9-8d30-7681c0c4d277" />
<img width="715" height="676" alt="image" src="https://github.com/user-attachments/assets/97014a53-473e-415e-920a-4c064ebac4d8" />
<img width="699" height="667" alt="image" src="https://github.com/user-attachments/assets/2227d924-c80e-41aa-9014-8ec68e669afd" />
<img width="572" height="654" alt="image" src="https://github.com/user-attachments/assets/51d34fbb-f10f-4042-849d-08cbf0a0f102" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
장소 데이터 적재 이후 최종 테스트 해 본 결과입니다 !
시큐리티 부분은 테스트 시 `.requestMatchers("/api/v1/**").permitAll()` 이 부분 주석 처리 후 진행했습니다.
