### PR TITLE
[Feature] 회원가입 이메일 인증 기능 구현

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -61,6 +61,9 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    // email (회원가입 인증)
+    implementation ("org.springframework.boot:spring-boot-starter-mail")
 }
 
 tasks.withType<Test> {

--- a/backend/src/main/java/com/backend/petplace/domain/email/dto/request/CheckAuthCodeRequest.java
+++ b/backend/src/main/java/com/backend/petplace/domain/email/dto/request/CheckAuthCodeRequest.java
@@ -9,10 +9,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public class CheckAuthCodeRequest {
 
-  @NotBlank
+  @NotBlank(message = "이메일은 필수입니다.")
   @Email
   private String email;
 
-  @NotBlank
+  @NotBlank(message = "인증번호는 필수입니다.")
   private String authCode;
 }

--- a/backend/src/main/java/com/backend/petplace/domain/email/dto/request/CheckAuthCodeRequest.java
+++ b/backend/src/main/java/com/backend/petplace/domain/email/dto/request/CheckAuthCodeRequest.java
@@ -1,0 +1,18 @@
+package com.backend.petplace.domain.email.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CheckAuthCodeRequest {
+
+  @NotBlank
+  @Email
+  private String email;
+
+  @NotBlank
+  private String authCode;
+}

--- a/backend/src/main/java/com/backend/petplace/domain/email/entity/EmailAuthCode.java
+++ b/backend/src/main/java/com/backend/petplace/domain/email/entity/EmailAuthCode.java
@@ -1,0 +1,49 @@
+package com.backend.petplace.domain.email.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailAuthCode {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String authCode;
+
+  @Column(nullable = false)
+  private String email;
+
+  @Column(nullable = false)
+  private LocalDateTime expiredAt;
+
+  @Builder
+  public EmailAuthCode(String authCode, String email, LocalDateTime expiredAt) {
+    this.authCode = authCode;
+    this.email = email;
+    this.expiredAt = expiredAt;
+  }
+
+  public static EmailAuthCode create(String email, String authCode, long authCodeExpirationTime) {
+    return EmailAuthCode.builder()
+        .email(email)
+        .authCode(authCode)
+        .expiredAt(LocalDateTime.now().plusMinutes(authCodeExpirationTime))
+        .build();
+  }
+
+  public boolean isExpired() {
+    return LocalDateTime.now().isAfter(expiredAt);
+  }
+}

--- a/backend/src/main/java/com/backend/petplace/domain/email/entity/EmailAuthCode.java
+++ b/backend/src/main/java/com/backend/petplace/domain/email/entity/EmailAuthCode.java
@@ -28,11 +28,15 @@ public class EmailAuthCode {
   @Column(nullable = false)
   private LocalDateTime expiredAt;
 
+  @Column(nullable = false)
+  private boolean verified;
+
   @Builder
-  public EmailAuthCode(String authCode, String email, LocalDateTime expiredAt) {
+  public EmailAuthCode(String authCode, String email, LocalDateTime expiredAt,  boolean verified) {
     this.authCode = authCode;
     this.email = email;
     this.expiredAt = expiredAt;
+    this.verified = verified;
   }
 
   public static EmailAuthCode create(String email, String authCode, long authCodeExpirationTime) {
@@ -40,10 +44,15 @@ public class EmailAuthCode {
         .email(email)
         .authCode(authCode)
         .expiredAt(LocalDateTime.now().plusMinutes(authCodeExpirationTime))
+        .verified(false)
         .build();
   }
 
   public boolean isExpired() {
     return LocalDateTime.now().isAfter(expiredAt);
+  }
+
+  public void markVerifiedTrue() {
+    this.verified = true;
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/email/repository/EmailAuthCodeRepository.java
+++ b/backend/src/main/java/com/backend/petplace/domain/email/repository/EmailAuthCodeRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface EmailAuthCodeRepository extends JpaRepository<EmailAuthCode, String> {
 
   Optional<EmailAuthCode> findByEmailAndAuthCode(String email, String authCode);
+
+  Optional<EmailAuthCode> findByEmail(String email);
 }

--- a/backend/src/main/java/com/backend/petplace/domain/email/repository/EmailAuthCodeRepository.java
+++ b/backend/src/main/java/com/backend/petplace/domain/email/repository/EmailAuthCodeRepository.java
@@ -1,0 +1,10 @@
+package com.backend.petplace.domain.email.repository;
+
+import com.backend.petplace.domain.email.entity.EmailAuthCode;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmailAuthCodeRepository extends JpaRepository<EmailAuthCode, String> {
+
+  Optional<EmailAuthCode> findByEmailAndAuthCode(String email, String authCode);
+}

--- a/backend/src/main/java/com/backend/petplace/domain/email/service/EmailAuthCodeService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/email/service/EmailAuthCodeService.java
@@ -27,7 +27,7 @@ public class EmailAuthCodeService {
   @Value("${spring.mail.username}")
   private String senderEmail;
 
-  @Value("${spring.mail.properties.auth-code-expiration-millis}")
+  @Value("${spring.mail.properties.auth-code-expiration-minutes}")
   private long authCodeExpirationTime;
 
   private static final String TITLE = "[PetPlace] Email 인증 코드";

--- a/backend/src/main/java/com/backend/petplace/domain/email/service/EmailAuthCodeService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/email/service/EmailAuthCodeService.java
@@ -106,7 +106,10 @@ public class EmailAuthCodeService {
       throw new BusinessException(ErrorCode.AUTH_CODE_EXPIRED);
     }
 
-    emailAuthCodeRepository.delete(emailAuthCode); // 인증 성공 시 삭제
+    // 성공하면 인증번호 값을 true로 변경
+    if (!emailAuthCode.isVerified()) {
+      emailAuthCode.markVerifiedTrue();
+    }
     return new BoolResultResponse(true);
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/controller/UserController.java
@@ -2,15 +2,20 @@ package com.backend.petplace.domain.user.controller;
 
 import com.backend.petplace.domain.user.dto.request.UserLoginRequest;
 import com.backend.petplace.domain.user.dto.request.UserSignupRequest;
+import com.backend.petplace.domain.user.dto.response.BoolResultResponse;
 import com.backend.petplace.domain.user.dto.response.UserSignupResponse;
 import com.backend.petplace.domain.user.service.UserService;
 import com.backend.petplace.global.response.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,6 +24,22 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController implements UserSpecification {
 
   private final UserService userService;
+
+  @GetMapping("/signup-username")
+  public ResponseEntity<ApiResponse<BoolResultResponse>> checkNickName(
+      @RequestParam @NotBlank String nickName
+  ) {
+    BoolResultResponse response = userService.validateDuplicateNickName(nickName);
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
+
+  @GetMapping("/signup-email")
+  public ResponseEntity<ApiResponse<BoolResultResponse>> checkEmail(
+      @RequestParam @NotBlank @Email String email
+  ) {
+    BoolResultResponse response = userService.validateDuplicateEmail(email);
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
 
   @PostMapping("/signup")
   public ResponseEntity<ApiResponse<UserSignupResponse>> signup(

--- a/backend/src/main/java/com/backend/petplace/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/controller/UserController.java
@@ -27,16 +27,16 @@ public class UserController implements UserSpecification {
 
   @GetMapping("/signup-username")
   public ResponseEntity<ApiResponse<BoolResultResponse>> checkNickName(
-      @RequestParam @NotBlank String nickName
-  ) {
+      @RequestParam @NotBlank String nickName) {
+
     BoolResultResponse response = userService.validateDuplicateNickName(nickName);
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 
   @GetMapping("/signup-email")
   public ResponseEntity<ApiResponse<BoolResultResponse>> checkEmail(
-      @RequestParam @NotBlank @Email String email
-  ) {
+      @RequestParam @NotBlank @Email String email) {
+
     BoolResultResponse response = userService.validateDuplicateEmail(email);
     return ResponseEntity.ok(ApiResponse.success(response));
   }

--- a/backend/src/main/java/com/backend/petplace/domain/user/controller/UserEmailVerificationController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/controller/UserEmailVerificationController.java
@@ -1,26 +1,40 @@
 package com.backend.petplace.domain.user.controller;
 
-import com.backend.petplace.global.email.MailService;
+import com.backend.petplace.domain.email.dto.request.CheckAuthCodeRequest;
+import com.backend.petplace.domain.email.service.EmailAuthCodeService;
 import com.backend.petplace.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/email/auth")
 @RequiredArgsConstructor
 public class UserEmailVerificationController {
 
-  private final MailService mailService;
+  private final EmailAuthCodeService EMailAuthCodeService;
 
-  @GetMapping("/email/auth/{email}")
-  public ResponseEntity<ApiResponse<Void>> sendVerificationCodeToEmail
-      (@PathVariable String email) {
+  @GetMapping
+  public ResponseEntity<ApiResponse<Void>> sendAuthCodeToEmail
+      (@RequestParam @NotBlank @Email String email) {
 
-    mailService.sendMail(email);
+    EMailAuthCodeService.sendMail(email);
+    return ResponseEntity.ok(ApiResponse.success());
+  }
+
+  @PatchMapping
+  public ResponseEntity<ApiResponse<Void>> checkAuthCode
+      (@RequestBody @Valid CheckAuthCodeRequest request) {
+
+    EMailAuthCodeService.checkAuthCode(request);
     return ResponseEntity.ok(ApiResponse.success());
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/user/controller/UserEmailVerificationController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/controller/UserEmailVerificationController.java
@@ -1,0 +1,26 @@
+package com.backend.petplace.domain.user.controller;
+
+import com.backend.petplace.global.email.MailService;
+import com.backend.petplace.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class UserEmailVerificationController {
+
+  private final MailService mailService;
+
+  @GetMapping("/email/auth/{email}")
+  public ResponseEntity<ApiResponse<Void>> sendVerificationCodeToEmail
+      (@PathVariable String email) {
+
+    mailService.sendMail(email);
+    return ResponseEntity.ok(ApiResponse.success());
+  }
+}

--- a/backend/src/main/java/com/backend/petplace/domain/user/controller/UserEmailVerificationController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/controller/UserEmailVerificationController.java
@@ -2,6 +2,7 @@ package com.backend.petplace.domain.user.controller;
 
 import com.backend.petplace.domain.email.dto.request.CheckAuthCodeRequest;
 import com.backend.petplace.domain.email.service.EmailAuthCodeService;
+import com.backend.petplace.domain.user.dto.response.BoolResultResponse;
 import com.backend.petplace.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
@@ -23,18 +24,18 @@ public class UserEmailVerificationController {
   private final EmailAuthCodeService EMailAuthCodeService;
 
   @GetMapping
-  public ResponseEntity<ApiResponse<Void>> sendAuthCodeToEmail
+  public ResponseEntity<ApiResponse<BoolResultResponse>> sendAuthCodeToEmail
       (@RequestParam @NotBlank @Email String email) {
 
-    EMailAuthCodeService.sendMail(email);
-    return ResponseEntity.ok(ApiResponse.success());
+    BoolResultResponse response = EMailAuthCodeService.sendMail(email);
+    return ResponseEntity.ok(ApiResponse.success(response));
   }
 
   @PatchMapping
-  public ResponseEntity<ApiResponse<Void>> checkAuthCode
+  public ResponseEntity<ApiResponse<BoolResultResponse>> checkAuthCode
       (@RequestBody @Valid CheckAuthCodeRequest request) {
 
-    EMailAuthCodeService.checkAuthCode(request);
-    return ResponseEntity.ok(ApiResponse.success());
+    BoolResultResponse response = EMailAuthCodeService.checkAuthCode(request);
+    return ResponseEntity.ok(ApiResponse.success(response));
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/user/controller/UserSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/controller/UserSpecification.java
@@ -13,7 +13,7 @@ public interface UserSpecification {
 
   @Operation(summary = "회원가입", description = "이용자가 회원가입을 제출합니다. 이름, 비밀번호, 이메일, 주소, 우편번호는 필수이며 상세주소는 선택입니다.")
   ResponseEntity<ApiResponse<UserSignupResponse>> signup(
-      @Parameter(description = "이름, 비밀번호, 이메일, 주소, 우편번호, 상세주소(선택)", required = true) UserSignupRequest request
+      @Parameter(description = "이름, 비밀번호, 주소, 우편번호, 상세주소(선택)", required = true) UserSignupRequest request
   );
 
   /*@Operation(summary = "로그인", description = "이용자가 로그인을 합니다. 이름, 비밀번호 필수입니다.")

--- a/backend/src/main/java/com/backend/petplace/domain/user/dto/request/UserSignupRequest.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/dto/request/UserSignupRequest.java
@@ -1,5 +1,6 @@
 package com.backend.petplace.domain.user.dto.request;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -23,7 +24,11 @@ public class UserSignupRequest {
   private String password;
 
   @NotBlank(message = "이메일은 필수입니다.")
+  @Email
   private String email;
+
+  @NotBlank(message = "인증번호는 필수입니다.")
+  private String authCode;
 
   @NotBlank(message = "주소는 필수입니다.")
   private String address;

--- a/backend/src/main/java/com/backend/petplace/domain/user/dto/response/BoolResultResponse.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/dto/response/BoolResultResponse.java
@@ -1,0 +1,11 @@
+package com.backend.petplace.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BoolResultResponse {
+
+  boolean result;
+}

--- a/backend/src/main/java/com/backend/petplace/domain/user/entity/User.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package com.backend.petplace.domain.user.entity;
 
 import com.backend.petplace.domain.order.entity.Order;
 import com.backend.petplace.domain.pet.entity.Pet;
+import com.backend.petplace.domain.user.dto.request.UserSignupRequest;
 import com.backend.petplace.global.entity.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -67,6 +68,17 @@ public class User extends BaseEntity {
     this.zipcode = zipcode;
     this.addressDetail = addressDetail;
     this.totalPoint = 10;
+  }
+
+  public static User create(UserSignupRequest request, String password) {
+    return User.builder()
+        .nickName(request.getNickName())
+        .password(password)
+        .email(request.getEmail())
+        .address(request.getAddress())
+        .zipcode(request.getZipcode())
+        .addressDetail(request.getAddressDetail())
+        .build();
   }
 
   //정적 팩토리 메서드를 통한 User 객체 생성

--- a/backend/src/main/java/com/backend/petplace/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/service/UserService.java
@@ -24,15 +24,8 @@ public class UserService {
 
   @Transactional
   public UserSignupResponse signup(UserSignupRequest request) {
-    User user = User.builder()
-        .nickName(request.getNickName())
-        .password(passwordEncoder.encode(request.getPassword()))
-        .email(request.getEmail())
-        .address(request.getAddress())
-        .zipcode(request.getZipcode())
-        .addressDetail(request.getAddressDetail())
-        .build();
 
+    User user = User.create(request, passwordEncoder.encode(request.getPassword()));
     userRepository.save(user);
 
     return new UserSignupResponse(user.getId());

--- a/backend/src/main/java/com/backend/petplace/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/service/UserService.java
@@ -28,8 +28,6 @@ public class UserService {
       throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
     }
 
-    // TODO:이메일 인증 기능 추가
-
     if (userRepository.existsByEmail(request.getEmail())) {
       throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
     }

--- a/backend/src/main/java/com/backend/petplace/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.backend.petplace.domain.user.service;
 
 import com.backend.petplace.domain.user.dto.request.UserLoginRequest;
 import com.backend.petplace.domain.user.dto.request.UserSignupRequest;
+import com.backend.petplace.domain.user.dto.response.BoolResultResponse;
 import com.backend.petplace.domain.user.dto.response.UserSignupResponse;
 import com.backend.petplace.domain.user.entity.User;
 import com.backend.petplace.domain.user.repository.UserRepository;
@@ -23,15 +24,6 @@ public class UserService {
 
   @Transactional
   public UserSignupResponse signup(UserSignupRequest request) {
-
-    if (userRepository.existsByNickName(request.getNickName())) {
-      throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
-    }
-
-    if (userRepository.existsByEmail(request.getEmail())) {
-      throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
-    }
-
     User user = User.builder()
         .nickName(request.getNickName())
         .password(passwordEncoder.encode(request.getPassword()))
@@ -44,6 +36,22 @@ public class UserService {
     userRepository.save(user);
 
     return new UserSignupResponse(user.getId());
+  }
+
+  @Transactional(readOnly = true)
+  public BoolResultResponse validateDuplicateNickName(String nickName) {
+    if (userRepository.existsByNickName(nickName)) {
+      throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+    }
+    return new BoolResultResponse(true);
+  }
+
+  @Transactional(readOnly = true)
+  public BoolResultResponse validateDuplicateEmail(String email) {
+    if (userRepository.existsByEmail(email)) {
+      throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
+    }
+    return new BoolResultResponse(true);
   }
 
   @Transactional(readOnly = true)

--- a/backend/src/main/java/com/backend/petplace/global/email/MailConfig.java
+++ b/backend/src/main/java/com/backend/petplace/global/email/MailConfig.java
@@ -1,0 +1,66 @@
+package com.backend.petplace.global.email;
+
+import java.util.Properties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class MailConfig {
+  @Value("${spring.mail.host}")
+  private String host;
+
+  @Value("${spring.mail.port}")
+  private int port;
+
+  @Value("${spring.mail.username}")
+  private String username;
+
+  @Value("${spring.mail.password}")
+  private String password;
+
+  @Value("${spring.mail.properties.mail.smtp.auth}")
+  private boolean auth;
+
+  @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+  private boolean starttlsEnable;
+
+  @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+  private boolean starttlsRequired;
+
+  @Value("${spring.mail.properties.mail.smtp.connection timeout}")
+  private int connectionTimeout;
+
+  @Value("${spring.mail.properties.mail.smtp.timeout}")
+  private int timeout;
+
+  @Value("${spring.mail.properties.mail.smtp.write timeout}")
+  private int writeTimeout;
+
+  @Bean
+  public JavaMailSender javaMailSender() {
+    JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+    mailSender.setHost(host);
+    mailSender.setPort(port);
+    mailSender.setUsername(username);
+    mailSender.setPassword(password);
+    mailSender.setDefaultEncoding("UTF-8");
+    mailSender.setJavaMailProperties(getMailProperties());
+
+    return mailSender;
+  }
+
+  private Properties getMailProperties() {
+    Properties properties = new Properties();
+    properties.put("mail.smtp.auth", auth);
+    properties.put("mail.smtp.starttls.enable", starttlsEnable);
+    properties.put("mail.smtp.starttls.required", starttlsRequired);
+    properties.put("mail.smtp.connection timeout", connectionTimeout);
+    properties.put("mail.smtp.timeout", timeout);
+    properties.put("mail.smtp.write timeout", writeTimeout);
+
+    return properties;
+  }
+}

--- a/backend/src/main/java/com/backend/petplace/global/email/MailService.java
+++ b/backend/src/main/java/com/backend/petplace/global/email/MailService.java
@@ -1,0 +1,86 @@
+package com.backend.petplace.global.email;
+
+import com.backend.petplace.global.exception.BusinessException;
+import com.backend.petplace.global.response.ErrorCode;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.net.SocketTimeoutException;
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailAuthenticationException;
+import org.springframework.mail.MailException;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+  private final JavaMailSender javaMailSender;
+  private static final String TITLE = "[PetPlace] Email 인증 코드";
+
+  @Value("${spring.mail.username}")
+  private String senderEmail;
+
+  public String createCode() {
+    Random random = new Random();
+    StringBuilder key = new StringBuilder();
+
+    for (int i = 0; i < 6; i++) { // 인증 코드 6자리
+      int index = random.nextInt(2); // 0~1까지 랜덤, 랜덤값으로 switch문 실행
+
+      switch (index) {
+        case 0 -> key.append((char) (random.nextInt(26) + 65)); // 대문자
+        case 1 -> key.append(random.nextInt(10)); // 숫자
+      }
+    }
+    return key.toString();
+  }
+
+  public MimeMessage createMail(String mail, String authCode) {
+    MimeMessage message = javaMailSender.createMimeMessage();
+
+    ValidateEmailFormat(mail);
+
+    try {
+      message.setFrom(senderEmail);
+      message.setRecipients(MimeMessage.RecipientType.TO, mail);
+      message.setSubject(TITLE);
+      String body = "";
+      body += "<h3>요청하신 인증 번호입니다.</h3>";
+      body += "<h1>" + authCode + "</h1>";
+      body += "<h3>감사합니다.</h3>";
+      message.setText(body, "UTF-8", "html");
+    } catch (MessagingException e) {
+      throw new BusinessException(ErrorCode.MAIL_CREATION_FAILED);
+    }
+    return message;
+  }
+
+  private void ValidateEmailFormat(String email) {
+     if (email == null || !email.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$")) {
+       throw new BusinessException(ErrorCode.INVALID_EMAIL_FORMAT);
+     }
+  }
+
+  // 메일 발송
+  public void sendMail(String sendEmail) {
+    String authCode = createCode(); // 랜덤 인증번호 생성
+    MimeMessage message = createMail(sendEmail, authCode); // 메일 생성
+
+    try {
+      javaMailSender.send(message); // 메일 발송
+    } catch (MailAuthenticationException e) {
+      throw new BusinessException(ErrorCode.MAIL_AUTH_FAILED);
+    } catch (MailSendException e) {
+      if (e.getCause() instanceof SocketTimeoutException) {
+        throw new BusinessException(ErrorCode.SMTP_CONNECTION_FAILED);
+      }
+      throw new BusinessException(ErrorCode.MAIL_SEND_FAILED);
+    } catch (MailException e) {
+      throw new BusinessException(ErrorCode.MAIL_SEND_FAILED);
+    }
+  }
+}

--- a/backend/src/main/java/com/backend/petplace/global/response/ErrorCode.java
+++ b/backend/src/main/java/com/backend/petplace/global/response/ErrorCode.java
@@ -47,7 +47,8 @@ public enum ErrorCode {
 
   // 인증 번호(Auth Code)
   AUTH_CODE_NOT_FOUND("AC001", HttpStatus.UNAUTHORIZED, "인증 번호가 존재하지 않습니다."),
-  AUTH_CODE_EXPIRED("AC002", HttpStatus.UNAUTHORIZED, "인증 번호가 만료되었습니다.");
+  AUTH_CODE_EXPIRED("AC002", HttpStatus.UNAUTHORIZED, "인증 번호가 만료되었습니다."),
+  AUTH_CODE_NOT_VERIFIED("AC003", HttpStatus.UNAUTHORIZED , "인증번호가 인증이 되지 않았습니다");
 
   private final String code;
   private final HttpStatus status;

--- a/backend/src/main/java/com/backend/petplace/global/response/ErrorCode.java
+++ b/backend/src/main/java/com/backend/petplace/global/response/ErrorCode.java
@@ -37,7 +37,14 @@ public enum ErrorCode {
 
   // 반려동물
   NOT_FOUND_PET("PET001", HttpStatus.NOT_FOUND, "존재하지 않는 반려동물입니다."),
-  ALREADY_DELETED("PET002", HttpStatus.BAD_REQUEST, "이미 삭제된 데이터입니다.");
+  ALREADY_DELETED("PET002", HttpStatus.BAD_REQUEST, "이미 삭제된 데이터입니다."),
+
+  // 이메일
+  MAIL_CREATION_FAILED("E001", HttpStatus.INTERNAL_SERVER_ERROR, "메일 생성에 실패했습니다."),
+  MAIL_SEND_FAILED("E002", HttpStatus.INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다."),
+  MAIL_AUTH_FAILED("E003", HttpStatus.UNAUTHORIZED, "메일 인증에 실패했습니다."),
+  INVALID_EMAIL_FORMAT("E004", HttpStatus.BAD_REQUEST, "이메일 형식이 올바르지 않습니다."),
+  SMTP_CONNECTION_FAILED("E005", HttpStatus.GATEWAY_TIMEOUT, "SMTP 서버와의 연결에 실패했습니다.");
 
   private final String code;
   private final HttpStatus status;

--- a/backend/src/main/java/com/backend/petplace/global/response/ErrorCode.java
+++ b/backend/src/main/java/com/backend/petplace/global/response/ErrorCode.java
@@ -43,8 +43,11 @@ public enum ErrorCode {
   MAIL_CREATION_FAILED("E001", HttpStatus.INTERNAL_SERVER_ERROR, "메일 생성에 실패했습니다."),
   MAIL_SEND_FAILED("E002", HttpStatus.INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다."),
   MAIL_AUTH_FAILED("E003", HttpStatus.UNAUTHORIZED, "메일 인증에 실패했습니다."),
-  INVALID_EMAIL_FORMAT("E004", HttpStatus.BAD_REQUEST, "이메일 형식이 올바르지 않습니다."),
-  SMTP_CONNECTION_FAILED("E005", HttpStatus.GATEWAY_TIMEOUT, "SMTP 서버와의 연결에 실패했습니다.");
+  SMTP_CONNECTION_FAILED("E004", HttpStatus.GATEWAY_TIMEOUT, "SMTP 서버와의 연결에 실패했습니다."),
+
+  // 인증 번호(Auth Code)
+  AUTH_CODE_NOT_FOUND("AC001", HttpStatus.UNAUTHORIZED, "인증 번호가 존재하지 않습니다."),
+  AUTH_CODE_EXPIRED("AC002", HttpStatus.UNAUTHORIZED, "인증 번호가 만료되었습니다.");
 
   private final String code;
   private final HttpStatus status;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -25,6 +25,22 @@ spring:
   http:
     codecs:
       max-in-memory-size: 16MB
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username:
+    password: ${app-password}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connection timeout: 5000
+          timeout: 500
+          write timeout: 5000
+      auth-code-expiration0millis: 300000  # 30 * 60 * 1000(밀리초) == 30분
 
 cloud:
   aws:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -38,7 +38,7 @@ spring:
             enable: true
             required: true
           connection timeout: 5000
-          timeout: 500
+          timeout: 5000
           write timeout: 5000
       auth-code-expiration0millis: 300000  # 30 * 60 * 1000(밀리초) == 30분
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -40,7 +40,7 @@ spring:
           connection timeout: 5000
           timeout: 5000
           write timeout: 5000
-      auth-code-expiration0millis: 180000  # 3 * 60 * 1000(밀리초) == 3분
+      auth-code-expiration-millis: 180000  # 3 * 60 * 1000(밀리초) == 3분
 
 cloud:
   aws:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -40,7 +40,7 @@ spring:
           connection timeout: 5000
           timeout: 5000
           write timeout: 5000
-      auth-code-expiration0millis: 300000  # 30 * 60 * 1000(밀리초) == 30분
+      auth-code-expiration0millis: 180000  # 3 * 60 * 1000(밀리초) == 3분
 
 cloud:
   aws:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -28,7 +28,7 @@ spring:
   mail:
     host: smtp.gmail.com
     port: 587
-    username:
+    username: ${my-email}
     password: ${app-password}
     properties:
       mail:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -28,8 +28,8 @@ spring:
   mail:
     host: smtp.gmail.com
     port: 587
-    username: ${my-email}
-    password: ${app-password}
+    username: ${MY_EMAIL}
+    password: ${APP_PASSWORD}
     properties:
       mail:
         smtp:
@@ -40,7 +40,7 @@ spring:
           connection timeout: 5000
           timeout: 5000
           write timeout: 5000
-      auth-code-expiration-millis: 180000  # 3 * 60 * 1000(밀리초) == 3분
+      auth-code-expiration-minutes: 3  # 3분
 
 cloud:
   aws:

--- a/backend/src/test/java/com/backend/petplace/domain/email/service/EmailAuthCodeServiceTest.java
+++ b/backend/src/test/java/com/backend/petplace/domain/email/service/EmailAuthCodeServiceTest.java
@@ -1,0 +1,47 @@
+package com.backend.petplace.domain.email.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.backend.petplace.domain.email.dto.request.CheckAuthCodeRequest;
+import com.backend.petplace.domain.email.entity.EmailAuthCode;
+import com.backend.petplace.domain.email.repository.EmailAuthCodeRepository;
+import com.backend.petplace.global.exception.BusinessException;
+import com.backend.petplace.global.response.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EmailAuthCodeServiceTest {
+
+  @Mock
+  private EmailAuthCodeRepository emailAuthCodeRepository;
+
+  @InjectMocks
+  private EmailAuthCodeService emailAuthCodeService;
+
+  @Test
+  void 인증번호가_만료되었으면_예외를_던진다() {
+    // given
+    String email = "test@example.com";
+    String authCode = "ABC1234";
+
+    EmailAuthCode expiredCode = EmailAuthCode.create(email, authCode, -1); // 이미 만료됨
+    CheckAuthCodeRequest request = new CheckAuthCodeRequest(email, authCode);
+
+    when(emailAuthCodeRepository.findByEmailAndAuthCode(email, authCode))
+        .thenReturn(Optional.of(expiredCode));
+
+    // when & then
+    BusinessException exception = assertThrows(BusinessException.class, () -> {
+      emailAuthCodeService.checkAuthCode(request);
+    });
+
+    assertEquals(ErrorCode.AUTH_CODE_EXPIRED, exception.getErrorCode());
+  }
+}

--- a/backend/src/test/java/com/backend/petplace/global/jwt/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/backend/petplace/global/jwt/JwtTokenProviderTest.java
@@ -37,7 +37,7 @@ class JwtTokenProviderTest {
     jwtTokenProvider.init();
   }
 
-  @DisplayName("JwtTokenProvider 단위 테스트: 암호화된 토큰 생성 & 파싱 확인")
+  @DisplayName("JwtTokenProvider 통합 테스트: 암호화된 토큰 생성 & 파싱 확인")
   @Test
   void token_shouldBeGeneratedAndParsedCorrectly() {
     // 토큰 생성


### PR DESCRIPTION
## 📌 관련 이슈
- close #97 

## 📝 변경 사항
### AS-IS
-  회원가입할 때, 이메일 인증, 검사 기능 부재
- 이메일 에러에 맞는 에러코드 부재
- 인증번호 검사하는 기능 부재!
- 이메일 인증번호 전송 & 인증 테스트 코드 부재
- 최종 회원가입 시에 모든 값을 검증하는 코드 부재

### TO-BE
- 사용자가 이메일 인증을 누름 -> 스프링 서버 요청 -> 이메일 서버 (SMTP서버)가 인증번호 를 보내줌 -> 인증번호 DB에 저장
-  인증번호는 랜덤으로 생성, 만료 시간 3분(`MailService`, `.yml`)
- 이메일 형식 체크, 예외처리(`MailService`)
- 에러코드 6개 추가(`ErrorCode`)
- 인증번호 비교를 위해 엔티티 추가(EmailAuthCode)
- 인증번호 비교&검사(DB에 있는지-이메일, 인증번호/만료시간 확인)
- 인증번호 받고 만료 확인 후, 예외 던지는 테스트 코드 작성
- 최종 회원가입 로직에 모든 값(이름, 이메일, 인증번호)을 검증하는 코드 추가 - 비밀번호는 DTO에서
- 최종 회원가입 요청 DTO에 인증번호(authCode) 추가

## 🔍 테스트
- [X] 테스트 코드 작성
- [x] API 테스트 - 성공, 실패(`E002`, `E004`) 확인
- [x] 로컬 테스트 - 오류x

## 📸 스크린샷
<img width="538" height="513" alt="image" src="https://github.com/user-attachments/assets/9f00dba2-f8a2-417a-901d-e69456a94353" />
<img width="476" height="532" alt="image" src="https://github.com/user-attachments/assets/393061ac-419a-4f34-94f7-c40a6cf5d5c2" />
<img width="492" height="538" alt="image" src="https://github.com/user-attachments/assets/0427b8e5-3973-4ec8-b56c-b0d99fb327c1" />
<img width="597" height="617" alt="스크린샷 2025-10-22 190456" src="https://github.com/user-attachments/assets/fc767a17-a494-481d-a1e0-016ea925c083" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 환경변수 값은 줌 채팅에 보내겠습니다~
- Gmail(javaMailSender) 사용했습니다.
- 응답 값 - 성공: true 실패:에러코드
- postman으로 통합테스트 과정 사진 https://www.notion.so/api-2959d0051b99803fa349c144c456835e?source=copy_link
- 커밋을 못 나눠서,, 커밋의 하위(상세) 설명을 보시면 될 것 같습니다.
<img width="660" height="327" alt="image" src="https://github.com/user-attachments/assets/b5827e94-21f4-4463-a314-34efb8957bd9" />

***코드가 난리법석인데 급해서 구현만 되게끔 만든 점 양해 부탁드립니다,,,,***
