### PR TITLE
feat: 구매 도메인 유저 포인트 조회

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderController.java
@@ -55,4 +55,12 @@ public class OrderController implements OrderSpecification {
     orderService.cancelOrder(userId, orderId);
     return ResponseEntity.ok(ApiResponse.success());
   }
+
+  @Override
+  @GetMapping("/points")
+  public ResponseEntity<ApiResponse<Integer>> getUserPoints(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    Long userId = userDetails.getUserId();
+    Integer points = orderService.getUserPoints(userId);
+    return ResponseEntity.ok(ApiResponse.success(points));
+  }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderSpecification.java
@@ -25,4 +25,7 @@ public interface OrderSpecification {
       @Parameter(description = "요청에서 받은 주문 아이디") Long orderId,
       @Parameter(description = "JWT토큰에서 받은 유저 정보") CustomUserDetails userDetails);
 
+  @Operation(summary = "사용자 포인트 조회", description = "특정 사용자의 현재 포인트 잔액을 조회합니다.")
+  ResponseEntity<ApiResponse<Integer>> getUserPoints(
+      @Parameter(description = "JWT토큰에서 받은 유저 정보") CustomUserDetails userDetails);
 }

--- a/backend/src/main/java/com/backend/petplace/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/service/OrderService.java
@@ -114,6 +114,12 @@ public class OrderService {
     orderRepository.save(order);
   }
 
+  public Integer getUserPoints(Long userId) {
+    return userRepository.findById(userId)
+        .map(User::getTotalPoint)
+        .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEMBER));
+  }
+
   @Transactional
   public void updateAllOrderStatus() {
 

--- a/frontend/app/products/page.tsx
+++ b/frontend/app/products/page.tsx
@@ -28,6 +28,9 @@ export default function ProductsPage() {
   useEffect(() => {
     if (!isAuthenticated()) {
       router.push("/login")
+    } else {
+      fetchUserPoints();
+      fetchOrders();
     }
   }, [router])
   
@@ -99,7 +102,8 @@ export default function ProductsPage() {
           },
         }
       )
-
+      await fetchUserPoints();
+      await fetchOrders();
       // 주문 상태 업데이트
       const newOrder: Order = {
         id: `order-${Date.now()}`,
@@ -190,6 +194,26 @@ export default function ProductsPage() {
       });
     }
   };
+
+  // 유저 포인트를 서버에서 가져오는 함수
+const fetchUserPoints = async () => {
+  try {
+    const response = await axios.get("http://localhost:8080/api/v1/orders/points", {
+      headers: { Authorization: token },
+    });
+
+    const points = response.data.data; // 서버가 totalPoint 값만 반환한다고 가정
+    setUserPoints(points);
+  } catch (err: any) {
+    console.error(err);
+    toast({
+      title: "포인트 조회 실패",
+      description: err.response?.data?.message || "서버 오류가 발생했습니다.",
+      variant: "destructive",
+    });
+  }
+};
+
 
   if (!isAuthenticated()) {
     return null


### PR DESCRIPTION
- 백엔드 구현: 컨트롤러/서비스/레포지토리/swagger용 interface
- 프론트 구현

<br></br>

## 📌 관련 이슈
- close #101

<br></br>


## 📝 변경 사항
### AS-IS
- 기존 코드의 동작 방식 설명
- 기존의 문제점 설명
- 1. 유저 포인트에 대해, DB와 프론트 연동 안되어있음

<br></br>


### TO-BE
- 변경된 내용 설명
- 문제가 해결된 방식 설명
- 1. 백엔드: 컨트롤러/서비스/레포지토리 구현
- 2. 백엔드: 이에 맞춰 swagger용 인터페이스도 처리
- 3. 프론트: 구매 화면 입장 시, 구매 완료 시 포인트 변화

<br></br>


## 🔍 테스트
- [] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

<br></br>


## 📸 스크린샷
// UI 변경사항이 있는 경우
- 포인트 조회 확인 (화면 입장 시)
<img width="922" height="850" alt="포인트 조회 확인 - 화면 입장 시" src="https://github.com/user-attachments/assets/3867e64f-041c-48c4-9fdd-89407ab872ff" />

<br></br>



- 포인트 조회 확인 (구매 후)
<img width="488" height="861" alt="포인트 조회 확인 - 구매 후" src="https://github.com/user-attachments/assets/12a269f8-b8be-4c72-97c6-b3ca0d6db018" />


<br></br>



## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

<br></br>


## 🙋‍♂️ 리뷰어에게
// 리뷰어가 집중해서 봐야 하는 부분
// 리뷰어에게 요청하고 싶은 사항


<br></br>


