### PR TITLE
[Feat] 프론트 개발

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderController.java
@@ -2,6 +2,7 @@ package com.backend.petplace.domain.order.controller;
 
 import com.backend.petplace.domain.order.dto.request.OrderCreateRequest;
 import com.backend.petplace.domain.order.dto.response.OrderReadByIdResponse;
+import com.backend.petplace.domain.order.entity.Order;
 import com.backend.petplace.domain.order.service.OrderService;
 import com.backend.petplace.global.jwt.CustomUserDetails;
 import com.backend.petplace.global.response.ApiResponse;
@@ -26,13 +27,13 @@ public class OrderController implements OrderSpecification {
 
   @Override
   @PostMapping()
-  public ResponseEntity<ApiResponse<Void>> createOrder(
+  public ResponseEntity<ApiResponse<Long>> createOrder(
       @RequestBody OrderCreateRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
 
     Long userId = userDetails.getUserId();
-    orderService.createOrder(request, userId);
-    return ResponseEntity.ok(ApiResponse.success());
+    Long orderId = orderService.createOrder(request, userId);
+    return ResponseEntity.ok(ApiResponse.success(orderId));
   }
 
   @Override
@@ -61,6 +62,7 @@ public class OrderController implements OrderSpecification {
   public ResponseEntity<ApiResponse<Integer>> getUserPoints(@AuthenticationPrincipal CustomUserDetails userDetails) {
     Long userId = userDetails.getUserId();
     Integer points = orderService.getUserPoints(userId);
+    System.out.println("controller: user points = " + points);
     return ResponseEntity.ok(ApiResponse.success(points));
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderController.java
@@ -62,7 +62,6 @@ public class OrderController implements OrderSpecification {
   public ResponseEntity<ApiResponse<Integer>> getUserPoints(@AuthenticationPrincipal CustomUserDetails userDetails) {
     Long userId = userDetails.getUserId();
     Integer points = orderService.getUserPoints(userId);
-    System.out.println("controller: user points = " + points);
     return ResponseEntity.ok(ApiResponse.success(points));
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/controller/OrderSpecification.java
@@ -12,7 +12,7 @@ import org.springframework.http.ResponseEntity;
 public interface OrderSpecification {
 
   @Operation(summary = "주문 생성", description = "새로운 주문을 생성합니다.")
-  ResponseEntity<ApiResponse<Void>> createOrder(
+  ResponseEntity<ApiResponse<Long>> createOrder(
       @Parameter(description = "가격 총액, 주문객체 리스트") OrderCreateRequest request,
       @Parameter(description = "JWT토큰에서 받은 유저 정보") CustomUserDetails userDetails);
 

--- a/backend/src/main/java/com/backend/petplace/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/service/OrderService.java
@@ -27,7 +27,7 @@ public class OrderService {
   private final ProductRepository productRepository;
 
   @Transactional
-  public void createOrder(OrderCreateRequest request, Long userId) {
+  public long createOrder(OrderCreateRequest request, Long userId) {
 
     // 기존 유저 읽어서 객체 생성
     User user = readUser(userId);
@@ -49,6 +49,8 @@ public class OrderService {
 
     // 저장
     orderRepository.save(order);
+
+    return order.getOrderId();
   }
 
   private User readUser(Long userId) {

--- a/backend/src/main/java/com/backend/petplace/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/order/service/OrderService.java
@@ -112,6 +112,11 @@ public class OrderService {
     // 주문 취소 상태로 저장
     order.cancelOrder();
     orderRepository.save(order);
+
+    // 주문 금액만큼 유저 포인트 복구
+    User user = order.getUser();
+    user.addPoints(order.getTotalPrice());
+    userRepository.save(user);
   }
 
   public Integer getUserPoints(Long userId) {

--- a/backend/src/main/java/com/backend/petplace/global/initdata/BaseInitData.java
+++ b/backend/src/main/java/com/backend/petplace/global/initdata/BaseInitData.java
@@ -73,7 +73,7 @@ public class BaseInitData implements CommandLineRunner {
     });
 
     // 10개의 주문 생성
-    for (int numberOfOrder = 0; numberOfOrder < 10; numberOfOrder++) {
+    for (int numberOfOrder = 0; numberOfOrder < 2; numberOfOrder++) {
       Order order = Order.createOrder(user, 1);
       OrderProduct orderProduct = OrderProduct.createOrderProduct(order, product, 1L);
       List<OrderProduct> orderProducts = new ArrayList<>();

--- a/backend/src/main/java/com/backend/petplace/global/scheduler/Scheduler.java
+++ b/backend/src/main/java/com/backend/petplace/global/scheduler/Scheduler.java
@@ -12,7 +12,7 @@ public class Scheduler {
 
   private final OrderService orderService;
 
-  @Scheduled(fixedRate = 1000 * 60 * 1) //1분마다 실행
+  //@Scheduled(fixedRate = 1000 * 60 * 1) //1분마다 실행
   public void updateOrderStatusEveryDay() {
     orderService.updateAllOrderStatus();
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,7 @@
     "sonner": "^1.7.4",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
+    "uuid": "^13.0.0",
     "vaul": "^0.9.9",
     "zod": "3.25.76"
   },


### PR DESCRIPTION
## 📌 관련 이슈
- close #109 
<br></br>

## 📝 변경 사항
### AS-IS
- 기존 코드의 동작 방식 설명
- 기존의 문제점 설명
- 1. 프론트가 백엔드와 연동 안되어 있었습니다.
<br></br>

### TO-BE
- 변경된 내용 설명
- 문제가 해결된 방식 설명
- 1. 주문 생성, 주문 조회, 주문 canceled로 상태 업데이트 관련 프론트 코드 구현
<br></br>

- 2. 주문 생성 후 주문 조회/주문 상태 업데이트와 연동하기 위해 주문 생성 response가 orderId 값 반환하도록 변경
- 3. 이에 따라 백엔드에서 주문 생성 관련 반환 타입, 컨트롤러, 서비스, swagger interface 일부 수정. 
<br></br>

- 4. 주문 포인트 조회도 프론트 코드 구현
<br></br>

## 🔍 테스트
- [] 테스트 코드 작성
- [X] API 테스트
- [X] 로컬 테스트
<br></br>

## 📸 스크린샷
### 주문 생성 전 (장바구니에 있는 값은 신경쓰지 말아주세요. 다른 값으로 주문합니다)
<img width="1918" height="574" alt="주문 생성 전" src="https://github.com/user-attachments/assets/bf4e13a8-a591-4c76-8770-bdff72af7c2b" />

### 화면 들어가자마자 포인트 연동
<img width="1893" height="581" alt="화면 들어가자마자 포인트 연동" src="https://github.com/user-attachments/assets/e4324267-b9af-4ffb-99c4-8bd41dc11718" />

### 주문 시도 전
<img width="1920" height="700" alt="주문 시도" src="https://github.com/user-attachments/assets/a24741be-e691-44bb-9851-5c9e523daf35" />

### 주문 후 포인트 차감
<img width="1897" height="829" alt="주문 후 포인트 차감" src="https://github.com/user-attachments/assets/f6300a06-e46e-4a65-b4fc-4906ec891d6c" />

### 주문 읽은 후, CANCELD 상태로 업데이트 시도 전
<img width="1902" height="935" alt="주문 읽기와 삭제 시도" src="https://github.com/user-attachments/assets/283187bf-de82-4cd7-969b-86f2bee3a993" />

### 주문 CANCELED 상태로 업데이트 후
<img width="1906" height="909" alt="취소 처리" src="https://github.com/user-attachments/assets/c1387a80-8877-451a-9dc2-78e60c79a581" />

### 주문 상태 업데이트 후에도 프론트와 백엔드 포인트 동일
<img width="1920" height="1080" alt="취소 후 포인트 동일" src="https://github.com/user-attachments/assets/71e5f495-164f-4820-9646-804dd819a3dd" />

<br></br>

## ✅ 체크리스트
- [X] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [X] 코딩 컨벤션을 준수했나요?
- [X] 불필요한 코드는 제거했나요?
- [X] 주석은 충분히 작성했나요?
- [X] 테스트는 완료했나요?
<br></br>

## 🙋‍♂️ 리뷰어에게
- Scheduler의 쓰지 않은 import문들은 주석처리한 @Scheduled 어노테이션을 풀고 테스트할 때 사용하는 거라 남겨두었습니다.

<br></br>
