### PR TITLE
[Refactor] Swagger 문서에 API 에러 코드 추가

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/mypage/controller/MyPageSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/mypage/controller/MyPageSpecification.java
@@ -1,6 +1,9 @@
 package com.backend.petplace.domain.mypage.controller;
 
+import static com.backend.petplace.global.response.ErrorCode.NOT_FOUND_MEMBER;
+
 import com.backend.petplace.domain.mypage.dto.response.MyPageResponse;
+import com.backend.petplace.global.config.swagger.ApiErrorCodeExamples;
 import com.backend.petplace.global.jwt.CustomUserDetails;
 import com.backend.petplace.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 @Tag(name = "마이페이지 API", description = "사용자 마이페이지 정보를 불러오는 API입니다.")
 public interface MyPageSpecification {
 
+  @ApiErrorCodeExamples({NOT_FOUND_MEMBER})
   @Operation(summary = "마이페이지 불러오기", description = "마이페이지 정보를 불러옵니다.")
   public ResponseEntity<ApiResponse<MyPageResponse>> myPage(CustomUserDetails user);
 }

--- a/backend/src/main/java/com/backend/petplace/domain/pet/controller/PetSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/pet/controller/PetSpecification.java
@@ -1,9 +1,14 @@
 package com.backend.petplace.domain.pet.controller;
 
+import static com.backend.petplace.global.response.ErrorCode.MEMBER_ACCESS_DENIED;
+import static com.backend.petplace.global.response.ErrorCode.NOT_FOUND_MEMBER;
+import static com.backend.petplace.global.response.ErrorCode.NOT_FOUND_PET;
+
 import com.backend.petplace.domain.pet.dto.request.CreatePetRequest;
 import com.backend.petplace.domain.pet.dto.request.UpdatePetRequest;
 import com.backend.petplace.domain.pet.dto.response.CreatePetResponse;
 import com.backend.petplace.domain.pet.dto.response.UpdatePetResponse;
+import com.backend.petplace.global.config.swagger.ApiErrorCodeExamples;
 import com.backend.petplace.global.jwt.CustomUserDetails;
 import com.backend.petplace.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,12 +22,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "Pet", description = "반려동물 API")
 public interface PetSpecification {
 
+  @ApiErrorCodeExamples({NOT_FOUND_MEMBER})
   @Operation(summary = "반려동물 생성", description = "사용자의 반려동물 정보를 생성합니다. 이름과 성별은 필수로 주어져야 합니다.")
   public ResponseEntity<ApiResponse<CreatePetResponse>> createPet(
       @Parameter(description = "반려동물 정보 - 이름, 성별, 생년월일, 품종", required = true) CreatePetRequest request,
       CustomUserDetails user
   );
 
+  @ApiErrorCodeExamples({MEMBER_ACCESS_DENIED, NOT_FOUND_PET})
   @Operation(summary = "반려동물 수정", description = "사용자의 반려동물 정보를 수정합니다. 수정하고 싶은 필드를 선택하여 데이터를 수정합니다.")
   public ResponseEntity<ApiResponse<UpdatePetResponse>> updatePet(
       @Parameter(description = "반려동물 ID") Long id,
@@ -30,6 +37,7 @@ public interface PetSpecification {
       CustomUserDetails user
   );
 
+  @ApiErrorCodeExamples({MEMBER_ACCESS_DENIED, NOT_FOUND_PET})
   @Operation(summary = "반려동물 삭제", description = "사용자의 반려동물 정보를 삭제합니다. 요청값이 요구되지 않습니다.")
   public ResponseEntity<ApiResponse<Void>> deletePet(
       @Parameter(description = "삭제할 반려동물 ID") Long id,


### PR DESCRIPTION
## 📌 관련 이슈
- close #113 

## 📝 변경 사항
### AS-IS
- Swagger 문서 mypage, pet 도메인에 에러코드 부재

### TO-BE
- Swagger 문서 mypage, pet 도메인에 에러코드 추가

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="951" height="913" alt="image" src="https://github.com/user-attachments/assets/ff1bbe67-25aa-4361-9915-66bfcded0ba1" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
어노테이션으로 오류 코드 추가했습니다!
커밋 메세지가 깨졌네요..

