### PR TITLE
[Feature] User, Email 관련 API Swagger 문서 작성 (로그인 리팩토링을 곁들인)

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.backend.petplace.domain.user.controller;
 import com.backend.petplace.domain.user.dto.request.UserLoginRequest;
 import com.backend.petplace.domain.user.dto.request.UserSignupRequest;
 import com.backend.petplace.domain.user.dto.response.BoolResultResponse;
+import com.backend.petplace.domain.user.dto.response.UserLoginResponse;
 import com.backend.petplace.domain.user.dto.response.UserSignupResponse;
 import com.backend.petplace.domain.user.service.UserService;
 import com.backend.petplace.global.response.ApiResponse;
@@ -50,10 +51,10 @@ public class UserController implements UserSpecification {
   }
 
   @PostMapping("/login")
-  public ResponseEntity<ApiResponse<String>> login(
+  public ResponseEntity<ApiResponse<UserLoginResponse>> login(
       @RequestBody UserLoginRequest request) {
 
-    String response = userService.login(request);
+    UserLoginResponse response = userService.login(request);
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/controller/UserController.java
@@ -58,7 +58,7 @@ public class UserController implements UserSpecification {
 
   @PostMapping("/login")
   public ResponseEntity<ApiResponse<UserLoginResponse>> login(
-      @RequestBody UserLoginRequest request) {
+      @Valid @RequestBody UserLoginRequest request) {
 
     UserLoginResponse response = userService.login(request);
     return ResponseEntity.ok(ApiResponse.success(response));

--- a/backend/src/main/java/com/backend/petplace/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/controller/UserController.java
@@ -10,6 +10,8 @@ import com.backend.petplace.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,7 +30,11 @@ public class UserController implements UserSpecification {
 
   @GetMapping("/signup-username")
   public ResponseEntity<ApiResponse<BoolResultResponse>> checkNickName(
-      @RequestParam @NotBlank String nickName) {
+      @RequestParam
+      @NotBlank
+      @Size(min = 2, max = 12)
+      @Pattern(regexp = "^[a-zA-Z0-9가-힣]+$")
+      String nickName) {
 
     BoolResultResponse response = userService.validateDuplicateNickName(nickName);
     return ResponseEntity.ok(ApiResponse.success(response));

--- a/backend/src/main/java/com/backend/petplace/domain/user/controller/UserEmailVerificationController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/controller/UserEmailVerificationController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Controller
 @RequestMapping("/api/v1/email/auth")
 @RequiredArgsConstructor
-public class UserEmailVerificationController {
+public class UserEmailVerificationController implements UserEmailVerificationSpecification{
 
   private final EmailAuthCodeService EMailAuthCodeService;
 

--- a/backend/src/main/java/com/backend/petplace/domain/user/controller/UserEmailVerificationSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/controller/UserEmailVerificationSpecification.java
@@ -1,0 +1,4 @@
+package com.backend.petplace.domain.user.controller;
+
+public interface UserEmailVerificationSpecification {
+}

--- a/backend/src/main/java/com/backend/petplace/domain/user/controller/UserEmailVerificationSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/controller/UserEmailVerificationSpecification.java
@@ -1,4 +1,35 @@
 package com.backend.petplace.domain.user.controller;
 
+import static com.backend.petplace.global.response.ErrorCode.AUTH_CODE_EXPIRED;
+import static com.backend.petplace.global.response.ErrorCode.AUTH_CODE_NOT_FOUND;
+import static com.backend.petplace.global.response.ErrorCode.MAIL_AUTH_FAILED;
+import static com.backend.petplace.global.response.ErrorCode.MAIL_CREATION_FAILED;
+import static com.backend.petplace.global.response.ErrorCode.MAIL_SEND_FAILED;
+import static com.backend.petplace.global.response.ErrorCode.SMTP_CONNECTION_FAILED;
+
+import com.backend.petplace.domain.email.dto.request.CheckAuthCodeRequest;
+import com.backend.petplace.domain.user.dto.response.BoolResultResponse;
+import com.backend.petplace.global.config.swagger.ApiErrorCodeExamples;
+import com.backend.petplace.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "User Email", description = "Email 인증 관련 API")
 public interface UserEmailVerificationSpecification {
+
+  @ApiErrorCodeExamples({MAIL_CREATION_FAILED, MAIL_AUTH_FAILED, SMTP_CONNECTION_FAILED, MAIL_SEND_FAILED})
+  @Operation(summary = "회원가입 이메일 인증번호 전송", description = "이메일 인증하기 버튼을 누르면 인증번호를 해당 이메일에 전송합니다. (유효성 검사: 빈칸 유무, 이메일 형식)")
+  ResponseEntity<ApiResponse<BoolResultResponse>> sendAuthCodeToEmail
+      (@RequestParam @NotBlank @Email String email);
+
+  @ApiErrorCodeExamples({AUTH_CODE_NOT_FOUND, AUTH_CODE_EXPIRED})
+  @Operation(summary = "회원가입 이메일 인증번호 검사", description = "인증 완료 버튼을 누르면 인증번호 검사를 실행합니다. (유효성 검사: 이메일 형식, 인증번호, 이메일 빈칸 유무)")
+  ResponseEntity<ApiResponse<BoolResultResponse>> checkAuthCode
+      (@RequestBody @Valid CheckAuthCodeRequest request);
 }

--- a/backend/src/main/java/com/backend/petplace/domain/user/controller/UserSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/controller/UserSpecification.java
@@ -16,8 +16,11 @@ import com.backend.petplace.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -25,25 +28,34 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface UserSpecification {
 
   @ApiErrorCodeExamples({DUPLICATE_NICKNAME})
-  @Operation(summary = "회원가입 중, 이름 중복 검사", description = "중복 검사 버튼을 누르면 검사를 실행합니다. 유효성 검사 - 길이(2~12), 영어, 한글, 숫자만 가능")
+  @Operation(summary = "회원가입 중, 이름 중복 검사", description = "중복 검사 버튼을 누르면 검사를 실행합니다. (유효성 검사: 길이(2~12), 영어, 한글, 숫자만 가능)")
   ResponseEntity<ApiResponse<BoolResultResponse>> checkNickName(
-      @RequestParam @NotBlank String nickName);
+      @RequestParam
+      @NotBlank
+      @Size(min = 2, max = 12)
+      @Pattern(regexp = "^[a-zA-Z0-9가-힣]+$")
+      String nickName
+  );
 
   @ApiErrorCodeExamples({DUPLICATE_EMAIL})
-  @Operation(summary = "회원가입 중, 이메일 중복 검사", description = "중복 검사 버튼을 누르면 검사를 실행합니다. 유효성 검사 - 이메일 형식, 빈 칸")
+  @Operation(summary = "회원가입 중, 이메일 중복 검사", description = "중복 검사 버튼을 누르면 검사를 실행합니다. (유효성 검사: 이메일 형식, 빈 칸)")
   ResponseEntity<ApiResponse<BoolResultResponse>> checkEmail(
-      @RequestParam @NotBlank @Email String email);
+      @RequestParam
+      @NotBlank
+      @Email
+      String email
+  );
 
   @ApiErrorCodeExamples({DUPLICATE_NICKNAME, DUPLICATE_EMAIL, AUTH_CODE_NOT_FOUND, AUTH_CODE_NOT_VERIFIED})
-  @Operation(summary = "회원가입", description = "이용자가 회원가입을 제출합니다. 이름, 비밀번호, 이메일, 주소, 우편번호는 필수이며 상세주소는 선택입니다.")
+  @Operation(summary = "회원가입", description = "이용자가 회원가입을 제출합니다. 이름, 비밀번호, 이메일, 인증번호, 주소, 우편번호는 필수이며 상세주소는 선택입니다.")
   ResponseEntity<ApiResponse<UserSignupResponse>> signup(
-      @Parameter(description = "이름, 비밀번호, 이메일, 주소, 우편번호, 상세주소(선택)", required = true) UserSignupRequest request
+      @Parameter(description = "이름, 비밀번호, 이메일, 인증번호, 주소, 우편번호, 상세주소(선택)", required = true) @Valid UserSignupRequest request
   );
 
   @ApiErrorCodeExamples({BAD_CREDENTIAL})
   @Operation(summary = "로그인", description = "이용자가 로그인을 합니다. 이름, 비밀번호 필수입니다.")
   ResponseEntity<ApiResponse<UserLoginResponse>> login(
-      @Parameter(description = "이름, 비밀번호", required = true) UserLoginRequest request
+      @Parameter(description = "이름, 비밀번호", required = true) @Valid UserLoginRequest request
   );
 
 }

--- a/backend/src/main/java/com/backend/petplace/domain/user/controller/UserSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/controller/UserSpecification.java
@@ -1,24 +1,49 @@
 package com.backend.petplace.domain.user.controller;
 
+import static com.backend.petplace.global.response.ErrorCode.AUTH_CODE_NOT_FOUND;
+import static com.backend.petplace.global.response.ErrorCode.AUTH_CODE_NOT_VERIFIED;
+import static com.backend.petplace.global.response.ErrorCode.BAD_CREDENTIAL;
+import static com.backend.petplace.global.response.ErrorCode.DUPLICATE_EMAIL;
+import static com.backend.petplace.global.response.ErrorCode.DUPLICATE_NICKNAME;
+
+import com.backend.petplace.domain.user.dto.request.UserLoginRequest;
 import com.backend.petplace.domain.user.dto.request.UserSignupRequest;
+import com.backend.petplace.domain.user.dto.response.BoolResultResponse;
+import com.backend.petplace.domain.user.dto.response.UserLoginResponse;
 import com.backend.petplace.domain.user.dto.response.UserSignupResponse;
+import com.backend.petplace.global.config.swagger.ApiErrorCodeExamples;
 import com.backend.petplace.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "User", description = "회원 API")
 public interface UserSpecification {
 
+  @ApiErrorCodeExamples({DUPLICATE_NICKNAME})
+  @Operation(summary = "회원가입 중, 이름 중복 검사", description = "중복 검사 버튼을 누르면 검사를 실행합니다. 유효성 검사 - 길이(2~12), 영어, 한글, 숫자만 가능")
+  ResponseEntity<ApiResponse<BoolResultResponse>> checkNickName(
+      @RequestParam @NotBlank String nickName);
+
+  @ApiErrorCodeExamples({DUPLICATE_EMAIL})
+  @Operation(summary = "회원가입 중, 이메일 중복 검사", description = "중복 검사 버튼을 누르면 검사를 실행합니다. 유효성 검사 - 이메일 형식, 빈 칸")
+  ResponseEntity<ApiResponse<BoolResultResponse>> checkEmail(
+      @RequestParam @NotBlank @Email String email);
+
+  @ApiErrorCodeExamples({DUPLICATE_NICKNAME, DUPLICATE_EMAIL, AUTH_CODE_NOT_FOUND, AUTH_CODE_NOT_VERIFIED})
   @Operation(summary = "회원가입", description = "이용자가 회원가입을 제출합니다. 이름, 비밀번호, 이메일, 주소, 우편번호는 필수이며 상세주소는 선택입니다.")
   ResponseEntity<ApiResponse<UserSignupResponse>> signup(
-      @Parameter(description = "이름, 비밀번호, 주소, 우편번호, 상세주소(선택)", required = true) UserSignupRequest request
+      @Parameter(description = "이름, 비밀번호, 이메일, 주소, 우편번호, 상세주소(선택)", required = true) UserSignupRequest request
   );
 
-  /*@Operation(summary = "로그인", description = "이용자가 로그인을 합니다. 이름, 비밀번호 필수입니다.")
-  void login(
-      @Parameter(description = "이름, 비밀번호", required = true) UserSignupRequest request
-  );*/
+  @ApiErrorCodeExamples({BAD_CREDENTIAL})
+  @Operation(summary = "로그인", description = "이용자가 로그인을 합니다. 이름, 비밀번호 필수입니다.")
+  ResponseEntity<ApiResponse<UserLoginResponse>> login(
+      @Parameter(description = "이름, 비밀번호", required = true) UserLoginRequest request
+  );
 
 }

--- a/backend/src/main/java/com/backend/petplace/domain/user/controller/UserSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/controller/UserSpecification.java
@@ -46,7 +46,8 @@ public interface UserSpecification {
       String email
   );
 
-  @ApiErrorCodeExamples({DUPLICATE_NICKNAME, DUPLICATE_EMAIL, AUTH_CODE_NOT_FOUND, AUTH_CODE_NOT_VERIFIED})
+  @ApiErrorCodeExamples({DUPLICATE_NICKNAME, DUPLICATE_EMAIL, AUTH_CODE_NOT_FOUND,
+      AUTH_CODE_NOT_VERIFIED})
   @Operation(summary = "회원가입", description = "이용자가 회원가입을 제출합니다. 이름, 비밀번호, 이메일, 인증번호, 주소, 우편번호는 필수이며 상세주소는 선택입니다.")
   ResponseEntity<ApiResponse<UserSignupResponse>> signup(
       @Parameter(description = "이름, 비밀번호, 이메일, 인증번호, 주소, 우편번호, 상세주소(선택)", required = true) @Valid UserSignupRequest request
@@ -57,5 +58,4 @@ public interface UserSpecification {
   ResponseEntity<ApiResponse<UserLoginResponse>> login(
       @Parameter(description = "이름, 비밀번호", required = true) @Valid UserLoginRequest request
   );
-
 }

--- a/backend/src/main/java/com/backend/petplace/domain/user/dto/request/UserLoginRequest.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/dto/request/UserLoginRequest.java
@@ -1,5 +1,8 @@
 package com.backend.petplace.domain.user.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,6 +10,15 @@ import lombok.Getter;
 @AllArgsConstructor
 public class UserLoginRequest {
 
+  @NotBlank
+  @Size(min = 2, max = 12, message = "이름은 2 ~ 12자까지 가능합니다.")
+  @Pattern(regexp = "^[a-zA-Z0-9가-힣]+$", message = "영문, 숫자, 한글만 사용할 수 있습니다.")
   String nickName;
+
+  @NotBlank
+  @Size(min = 8, max = 12, message = "비밀번호는 8 ~ 12자까지 가능합니다.")
+  @Pattern(
+      regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+{}\\[\\]:;<>,.?~\\-=/])[A-Za-z\\d!@#$%^&*()_+{}\\[\\]:;<>,.?~\\-=/]+$",
+      message = "영어, 숫자, 특수문자를 모두 포함해야 합니다.")
   String password;
 }

--- a/backend/src/main/java/com/backend/petplace/domain/user/dto/response/UserLoginResponse.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/dto/response/UserLoginResponse.java
@@ -1,0 +1,11 @@
+package com.backend.petplace.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserLoginResponse {
+
+  String token;
+}

--- a/backend/src/main/java/com/backend/petplace/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.backend.petplace.domain.email.repository.EmailAuthCodeRepository;
 import com.backend.petplace.domain.user.dto.request.UserLoginRequest;
 import com.backend.petplace.domain.user.dto.request.UserSignupRequest;
 import com.backend.petplace.domain.user.dto.response.BoolResultResponse;
+import com.backend.petplace.domain.user.dto.response.UserLoginResponse;
 import com.backend.petplace.domain.user.dto.response.UserSignupResponse;
 import com.backend.petplace.domain.user.entity.User;
 import com.backend.petplace.domain.user.repository.UserRepository;
@@ -70,7 +71,7 @@ public class UserService {
   }
 
   @Transactional(readOnly = true)
-  public String login(UserLoginRequest request) {
+  public UserLoginResponse login(UserLoginRequest request) {
     User user = userRepository.findByNickName(request.getNickName())
         .orElseThrow(() -> new BusinessException(ErrorCode.BAD_CREDENTIAL));
 
@@ -78,6 +79,6 @@ public class UserService {
       throw new BusinessException(ErrorCode.BAD_CREDENTIAL);
     }
 
-    return jwtTokenProvider.generateAccessToken(user.getId());
+    return new UserLoginResponse(jwtTokenProvider.generateAccessToken(user.getId()));
   }
 }

--- a/backend/src/main/java/com/backend/petplace/global/config/security/SecurityConfig.java
+++ b/backend/src/main/java/com/backend/petplace/global/config/security/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
             .requestMatchers("/h2-console/**").permitAll()
             .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
             .requestMatchers("/api/v1/signup", "/api/v1/login").permitAll() // 회원가입, 로그인
+            .requestMatchers("/api/v1/signup-username", "/api/v1/signup-email").permitAll()
             .requestMatchers("/api/v1/places/{placeId}/reviews").permitAll() // 장소별 리뷰 조회
             .requestMatchers("/api/v1/**").permitAll()
             .anyRequest().authenticated()


### PR DESCRIPTION
## 📌 관련 이슈
- close #117 

## 📝 변경 사항
### AS-IS
- Swagger 문서에 User, Email 관련 API를 명시한 코드가 없거나 완성되지 않았다.
- 로그인 응답이 일관성이 없었다.
- 로그인 요청의 유효성 검사를 위한 애노테이션 부재

### TO-BE
- Swagger 문서에 User, Email 관련 API를 명시한 코드가 없거나 완성 및 Swagger에서 execute할 수 있게 작성
- 로그인 응답을 DTO로 변경.
- 로그인 요청의 유효성 검사를 위한 애노테이션 추가(@Valid, @NotBlank 등)
- SecurityConfig에 주소 추가(2개)

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
테스트랑 마지막에 체크했지만 정신없이 해서 실수가 있을 수 도,,,, 있습니다.(실행은 잘 됩니다!)
*혹시  Swagger에서 본인의 api 테스트시 잘 안되시면 매개변수 애노테이션이 일치하지 않은 것 때문일 수 있습니다!*


