### PR TITLE
[Docs] Place API 문서화(@ApiErrorCodeExamples, @Schema) 및 주석 정리

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/controller/PlaceSpecification.java
@@ -1,8 +1,11 @@
 package com.backend.petplace.domain.place.controller;
 
+import static com.backend.petplace.global.response.ErrorCode.NOT_FOUND_PLACE;
+
 import com.backend.petplace.domain.place.dto.response.PlaceDetailResponse;
 import com.backend.petplace.domain.place.dto.response.PlaceSearchResponse;
 import com.backend.petplace.domain.place.entity.Category2Type;
+import com.backend.petplace.global.config.swagger.ApiErrorCodeExamples;
 import com.backend.petplace.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -49,6 +52,7 @@ public interface PlaceSpecification {
       String keyword
   );
 
+  @ApiErrorCodeExamples({NOT_FOUND_PLACE})
   @Operation(summary = "장소 상세 조회", description = "장소 ID로 상세 정보를 조회합니다.")
   ResponseEntity<ApiResponse<PlaceDetailResponse>> getPlaceDetail(
       @Parameter(in = ParameterIn.PATH, description = "장소 ID", required = true)

--- a/backend/src/main/java/com/backend/petplace/domain/place/dto/request/PlaceRequest.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/dto/request/PlaceRequest.java
@@ -1,5 +1,0 @@
-package com.backend.petplace.domain.place.dto.request;
-
-public class PlaceRequest {
-
-}

--- a/backend/src/main/java/com/backend/petplace/domain/place/dto/response/PlaceSearchResponse.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/dto/response/PlaceSearchResponse.java
@@ -19,7 +19,7 @@ public record PlaceSearchResponse(
     return new PlaceSearchResponse(
         row.getId(),
         row.getName(),
-        Category2Type.valueOf(row.getCategory2()), // 문자열 → Enum 변환
+        Category2Type.valueOf(row.getCategory2()),
         row.getLatitude(),
         row.getLongitude(),
         row.getDistanceMeters(),

--- a/backend/src/main/java/com/backend/petplace/domain/place/dto/response/PlaceSearchResponse.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/dto/response/PlaceSearchResponse.java
@@ -2,16 +2,18 @@ package com.backend.petplace.domain.place.dto.response;
 
 import com.backend.petplace.domain.place.entity.Category2Type;
 import com.backend.petplace.domain.place.projection.PlaceSearchRow;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record PlaceSearchResponse(
-    Long id,
-    String name,
+    @Schema(description = "장소 ID", example = "123") Long id,
+    @Schema(description = "장소명", example = "행복동물병원") String name,
+    @Schema(description = "중분류(검색 필터 주요 기준)", example = "VET_HOSPITAL", implementation = Category2Type.class)
     Category2Type category2,
-    double latitude,
-    double longitude,
-    int distanceMeters,
-    Double averageRating,
-    String address
+    @Schema(description = "위도", example = "37.5665") double latitude,
+    @Schema(description = "경도", example = "126.9780")double longitude,
+    @Schema(description = "요청 좌표로부터 거리(미터)", example = "842", minimum = "0") int distanceMeters,
+    @Schema(description = "평균 평점", example = "4.6", minimum = "0", maximum = "5") Double averageRating,
+    @Schema(description = "주소", example = "서울특별시 중구 세종대로 110") String address
 ) {
   public static PlaceSearchResponse from(PlaceSearchRow row) {
     return new PlaceSearchResponse(

--- a/backend/src/main/java/com/backend/petplace/domain/place/entity/Place.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/entity/Place.java
@@ -36,7 +36,6 @@ public class Place extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  // uniqueKey = 장소명 + 우편번호 (중복되는 데이터가 생기는 걸 방지하기 위한 컬럼)
   @Column(nullable = false, length = 100, unique = true)
   private String uniqueKey;
 
@@ -52,17 +51,17 @@ public class Place extends BaseEntity {
   private Category2Type category2;
 
   @Column(length = 500)
-  private String openingHours;   // 예: "월~금 09:00~18:00"
+  private String openingHours;
 
   @Column(length = 300)
-  private String closedDays;     // 예: "매주 토/일, 공휴일"
+  private String closedDays;
 
   private Boolean parking;
 
   private Boolean petAllowed;
 
   @Column(length = 300)
-  private String petRestriction; // 예: "야외만", "목줄", "제한 없음"
+  private String petRestriction;
 
   @Column(length = 30)
   private String tel;
@@ -71,19 +70,19 @@ public class Place extends BaseEntity {
   private String url;
 
   @Column(length = 10)
-  private String postalCode;     // 5자리 우편번호
+  private String postalCode;
 
   @Column(length = 300)
-  private String address;        // 우편번호 제거한 주소 본문
+  private String address;
 
   @Column(nullable = false)
-  private Double latitude;       // 위도
+  private Double latitude;
 
   @Column(nullable = false)
-  private Double longitude;      // 경도
+  private Double longitude;
 
   @Column(length = 1000)
-  private String rawDescription; // 원본 description
+  private String rawDescription;
 
   @Builder.Default
   private Double averageRating = 0.0;
@@ -97,7 +96,6 @@ public class Place extends BaseEntity {
     this.averageRating = (totalScore + newRating) / this.totalReviewCount;
   }
 
-  // 업서트 업데이트 시 필드 동기화 메서드
   public void apply(String name, Category1Type c1, Category2Type c2, String openingHours,
       String closedDays, Boolean parking, Boolean petAllowed, String petRestriction,
       String tel, String url, String postalCode, String address, Double lat, Double lng,

--- a/backend/src/main/java/com/backend/petplace/domain/place/service/PlaceService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/service/PlaceService.java
@@ -28,7 +28,7 @@ public class PlaceService {
       double lat, double lon,
       Integer radiusKm,
       List<Category2Type> category2List,
-      String keyword // ← 이름 맞춤
+      String keyword
   ) {
     int rk = (radiusKm == null ? DEFAULT_RADIUS_KM : Math.min(radiusKm, MAX_RADIUS_KM));
     int radiusMeters = rk * 1_000;


### PR DESCRIPTION
**📌 관련 이슈**

* close #118 

**📝 변경 사항**

### AS-IS

* 장소 검색/상세 API의 Swagger 문서가 최소 수준으로만 제공되어 파라미터 설명과 응답 스키마 가독성이 낮았음
* 상세 조회 시 발생 가능한 에러 코드 사례(예: NOT_FOUND_PLACE)가 문서화되어 있지 않음
* 파일 내 불필요/중복 주석 존재

### TO-BE

* `PlaceSpecification`

  * `@ApiErrorCodeExamples({NOT_FOUND_PLACE})` 추가로 상세 조회 에러 케이스 문서화
* `PlaceSearchResponse`

  * 각 필드에 `@Schema` 주석(설명, example, 범위) 추가 → Swagger 응답 스키마 가독성 향상
* 불필요 주석 정리 (동작 로직 변경 없음, 문서화 개선 목적)

**🔍 테스트**

* [ ] 테스트 코드 작성
* [x] API 테스트
* [x] 로컬 테스트

**📸 스크린샷**
<img width="1566" height="1612" alt="image" src="https://github.com/user-attachments/assets/7a6af515-ec48-4cbb-81ad-f99400f791d0" />

<img width="1356" height="1092" alt="image" src="https://github.com/user-attachments/assets/a535157e-63b3-4ede-98b2-d26c9b7b728e" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 확인 부탁드립니다!

