### PR TITLE
[Feature] [FE] 장소 상세 조회 전체 정보 반영 및 지도 마커 개선, 검색 결과 확장 (100 → 300)

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/place/service/PlaceService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/service/PlaceService.java
@@ -21,7 +21,7 @@ public class PlaceService {
 
   private static final int DEFAULT_RADIUS_KM = 10;
   private static final int MAX_RADIUS_KM = 30;
-  private static final int DEFAULT_SIZE = 100;
+  private static final int DEFAULT_SIZE = 300;
 
   @Transactional(readOnly = true)
   public List<PlaceSearchResponse> searchPlaces(

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -20,7 +20,7 @@ import {
   CATEGORY2_OPTIONS,
 } from "./placeService"
 
-// 지도는 SSR 끔
+
 const MapView = dynamic(() => import("@/components/MapView"), { ssr: false })
 
 export default function SearchPage() {
@@ -63,7 +63,6 @@ export default function SearchPage() {
     }
   }, [mounted])
 
-  // 카테고리 옵션 (ETC 제외, placeService에서 공급)
   const categories = useMemo(() => CATEGORY2_OPTIONS, [])
 
   const runSearch = async (overrides?: { keyword?: string; category2?: string | null }) => {
@@ -76,7 +75,6 @@ export default function SearchPage() {
       lon: userCenter[1],
       radiusKm: radius[0],
       keyword: overrides?.keyword ?? (keyword.trim() || undefined),
-      // ★ 서버 파라미터 키는 category2
       category2: overrides?.category2 ?? selectedCategory ?? undefined,
     }
     try {
@@ -109,7 +107,6 @@ export default function SearchPage() {
       const res = await getPlaceDetail(place.id)
       setDetail(res.data)
     } catch {
-      // 상세 실패해도 사이드바는 열어둠
     } finally {
       setDetailLoading(false)
     }
@@ -137,13 +134,13 @@ export default function SearchPage() {
               </Button>
             </div>
 
-            {/* 반경 */}
+            
             <div className="space-y-2">
               <label className="text-sm font-medium">반경: {radius[0]}km</label>
               <Slider value={radius} onValueChange={handleRadiusChange} min={1} max={30} step={1} className="w-full" />
             </div>
 
-            {/* 카테고리(ETC 제외 전부) */}
+            
             <div className="flex flex-wrap gap-2">
               {categories.map(({ value, label }) => (
                 <Button
@@ -157,7 +154,7 @@ export default function SearchPage() {
               ))}
             </div>
 
-            {/* 지도 + 결과 카드 */}
+            
             <div className="space-y-4">
               <div className="rounded-lg border border-border bg-muted/30 p-8">
                 <MapView center={userCenter} places={places} onSelectPlace={handlePlaceClick} />
@@ -176,7 +173,6 @@ export default function SearchPage() {
                       className="mb-2 h-32 w-full rounded object-cover"
                     />
                     <h3 className="font-semibold text-card-foreground">{place.name}</h3>
-                    {/* 🔽 중분류 한글 라벨로 표시 */}
                     <p className="text-xs text-muted-foreground">
                       {getCategory2Label(place.category2)}
                     </p>
@@ -190,7 +186,6 @@ export default function SearchPage() {
             </div>
           </div>
 
-          {/* 사이드바 – detail 전달 */}
           <PlaceSidebar
             place={selectedPlace as any}
             reviews={mockReviews.filter((r) => r.placeId === (selectedPlace as any)?.id)}

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -11,26 +11,16 @@ import { mockReviews } from "@/lib/mock-data"
 import { PlaceSidebar } from "@/components/place-sidebar"
 import { useToast } from "@/hooks/use-toast"
 import dynamic from "next/dynamic"
-import { searchPlaces, getPlaceDetail, type PlaceDto } from "./placeService"
+import {
+  searchPlaces,
+  getPlaceDetail,
+  type PlaceDto,
+  type PlaceDetailResponse,
+  getCategory2Label,
+} from "./placeService"
 
-// 지도는 브라우저 전용
+// 지도는 SSR 끔
 const MapView = dynamic(() => import("@/components/MapView"), { ssr: false })
-
-const CATEGORY_MAP: Record<string, string> = {
-  "동물약국": "VET_PHARMACY",
-  "박물관": "MUSEUM",
-  "카페": "CAFE",
-  "동물병원": "VET_HOSPITAL",
-  "반려동물용품": "PET_SUPPLIES",
-  "미용": "GROOMING",
-  "문예회관": "ART_CENTER",
-  "펜션": "PENSION",
-  "식당": "RESTAURANT",
-  "여행지": "DESTINATION",
-  "위탁관리": "DAYCARE",
-  "미술관": "ART_MUSEUM",
-  "기타": "ETC",
-}
 
 export default function SearchPage() {
   const router = useRouter()
@@ -39,18 +29,24 @@ export default function SearchPage() {
   const [mounted, setMounted] = useState(false)
   useEffect(() => { setMounted(true) }, [])
   useEffect(() => {
-    if (!isAuthenticated()) router.push("/login")
+    if (!isAuthenticated()) {
+      router.push("/login")
+    }
   }, [router])
 
   const [keyword, setKeyword] = useState("")
-  const [radius, setRadius] = useState([10]) // km
-  const [selectedCategoryLabel, setSelectedCategoryLabel] = useState<string | null>(null)
+  const [radius, setRadius] = useState([10])
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
 
   const [userCenter, setUserCenter] = useState<[number, number] | null>(null)
   const [places, setPlaces] = useState<PlaceDto[]>([])
   const [selectedPlace, setSelectedPlace] = useState<PlaceDto | null>(null)
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [loading, setLoading] = useState(false)
+
+  // 상세 조회 상태
+  const [detail, setDetail] = useState<PlaceDetailResponse | null>(null)
+  const [detailLoading, setDetailLoading] = useState(false)
 
   // 위치 권한
   useEffect(() => {
@@ -66,59 +62,54 @@ export default function SearchPage() {
     }
   }, [mounted])
 
-  // 버튼용 한글 라벨
-  const categories = useMemo(() => Object.keys(CATEGORY_MAP), [])
+  // (필요시) 카테고리 버튼은 별도로 유지/수정
+  const categories = useMemo(() => ["동물병원", "동물약국", "식당", "카페"], [])
 
-  const runSearch = async (overrides?: { keyword?: string; categoryLabel?: string | null }) => {
+  const runSearch = async (overrides?: { keyword?: string; category?: string | null }) => {
     if (!userCenter) {
-      toast({
-        title: "위치 확인 필요",
-        description: "내 위치를 확인한 후 검색해 주세요.",
-        variant: "destructive",
-      })
+      toast({ title: "위치 확인 필요", description: "내 위치를 확인한 후 검색해 주세요.", variant: "destructive" })
       return
     }
-
-    const label = overrides?.categoryLabel ?? selectedCategoryLabel
-    const category2 = label ? CATEGORY_MAP[label] : undefined
-
     const q = {
       lat: userCenter[0],
       lon: userCenter[1],
       radiusKm: radius[0],
       keyword: overrides?.keyword ?? (keyword.trim() || undefined),
-      category2,
+      // 서버는 category2(enum name)로 받으므로, 여기 버튼에서 enum을 넘기는 경우에만 값 세팅.
+      category: overrides?.category ?? selectedCategory ?? undefined,
     }
-
     try {
       setLoading(true)
       const res = await searchPlaces(q)
       setPlaces(res.data)
     } catch (e: any) {
-      toast({
-        title: "검색 실패",
-        description: e?.message || "잠시 후 다시 시도해 주세요.",
-        variant: "destructive",
-      })
+      toast({ title: "검색 실패", description: e?.message || "잠시 후 다시 시도해 주세요.", variant: "destructive" })
     } finally {
       setLoading(false)
     }
   }
 
   const handleSearch = () => runSearch()
-
-  const handleCategoryClick = (label: string) => {
-    const next = label === selectedCategoryLabel ? null : label
-    setSelectedCategoryLabel(next)
-    runSearch({ categoryLabel: next })
+  const handleCategoryClick = (category: string) => {
+    const next = category === selectedCategory ? null : category
+    setSelectedCategory(next)
+    runSearch({ category: next })
   }
-
   const handleRadiusChange = (value: number[]) => setRadius(value)
 
   const handlePlaceClick = async (place: PlaceDto) => {
     setSelectedPlace(place)
     setSidebarOpen(true)
-    // const detail = await getPlaceDetail(place.id)
+    setDetail(null)
+    setDetailLoading(true)
+    try {
+      const res = await getPlaceDetail(place.id)
+      setDetail(res.data)
+    } catch (e) {
+      // 상세 실패해도 사이드바는 열어둠 (목록 정보로 최소 표시)
+    } finally {
+      setDetailLoading(false)
+    }
   }
 
   if (!mounted) return null
@@ -127,16 +118,15 @@ export default function SearchPage() {
   return (
     <div className="min-h-screen bg-background">
       <Navigation />
-
       <main className="container mx-auto px-4 py-6">
         <div className="grid gap-6 lg:grid-cols-[1fr_400px]">
           <div className="space-y-4">
-            {/* 🔍 검색어 입력 + 버튼 */}
+            {/* 검색 입력 */}
             <div className="flex gap-2">
               <Input
                 value={keyword}
                 onChange={(e) => setKeyword(e.target.value)}
-                placeholder="장소명을 입력하세요 (선택)"
+                placeholder="장소를 검색하세요 (선택)"
                 onKeyDown={(e) => e.key === "Enter" && handleSearch()}
               />
               <Button onClick={handleSearch} disabled={loading}>
@@ -144,26 +134,26 @@ export default function SearchPage() {
               </Button>
             </div>
 
-            {/* 반경 슬라이더 */}
+            {/* 반경 */}
             <div className="space-y-2">
               <label className="text-sm font-medium">반경: {radius[0]}km</label>
-              <Slider value={radius} onValueChange={handleRadiusChange} min={1} max={30} step={1} />
+              <Slider value={radius} onValueChange={handleRadiusChange} min={1} max={30} step={1} className="w-full" />
             </div>
 
-            {/* 카테고리 선택 버튼 */}
-            <div className="flex flex-wrap gap-2">
-              {categories.map((label) => (
+            {/* (선택) 카테고리 버튼 – 현재는 표시/테스트용 */}
+            <div className="flex gap-2">
+              {categories.map((category) => (
                 <Button
-                  key={label}
-                  variant={selectedCategoryLabel === label ? "default" : "outline"}
-                  onClick={() => handleCategoryClick(label)}
+                  key={category}
+                  variant={selectedCategory === category ? "default" : "outline"}
+                  onClick={() => handleCategoryClick(category)}
                 >
-                  {label}
+                  {category}
                 </Button>
               ))}
             </div>
 
-            {/* 지도 + 결과 목록 */}
+            {/* 지도 + 결과 카드 */}
             <div className="space-y-4">
               <div className="rounded-lg border border-border bg-muted/30 p-8">
                 <MapView center={userCenter} places={places} onSelectPlace={handlePlaceClick} />
@@ -182,21 +172,28 @@ export default function SearchPage() {
                       className="mb-2 h-32 w-full rounded object-cover"
                     />
                     <h3 className="font-semibold text-card-foreground">{place.name}</h3>
-                    <p className="text-xs text-muted-foreground">{place.category2}</p>
+                    {/* 🔽 중분류 한글 라벨로 표시 */}
+                    <p className="text-xs text-muted-foreground">
+                      {getCategory2Label(place.category2)}
+                    </p>
                     <p className="text-xs text-muted-foreground">
                       {Math.round(place.distanceMeters / 100) / 10}km
                     </p>
+                    <p className="text-xs text-muted-foreground">{place.address}</p>
                   </button>
                 ))}
               </div>
             </div>
           </div>
 
+          {/* 사이드바 – 상세 koLabel 적용됨 */}
           <PlaceSidebar
             place={selectedPlace as any}
             reviews={mockReviews.filter((r) => r.placeId === (selectedPlace as any)?.id)}
             open={sidebarOpen}
             onOpenChange={setSidebarOpen}
+            detail={detail}
+            detailLoading={detailLoading}
           />
         </div>
       </main>

--- a/frontend/app/search/placeService.ts
+++ b/frontend/app/search/placeService.ts
@@ -1,9 +1,11 @@
 import { api } from '@/lib/api';
 
+/** ====== 공용 타입 ====== */
+
 export type PlaceDto = {
   id: number;
   name: string;
-  category2: string;      
+  category2: string;        // 서버에서 enum name으로 옴 (e.g., VET_PHARMACY)
   latitude: number;
   longitude: number;
   distanceMeters: number;
@@ -17,16 +19,79 @@ export type ApiResponse<T> = {
   data: T;
 };
 
+/** ====== 상세 응답 타입 (백엔드 DTO와 동일) ====== */
+export type PlaceDetailResponse = {
+  id: number;
+  name: string;
+  category1: string;        // enum name (e.g., PET_MEDICAL)
+  category2: string;        // enum name (e.g., VET_PHARMACY)
+  openingHours: string | null;
+  closedDays: string | null;
+  parking: boolean | null;
+  petAllowed: boolean | null;
+  petRestriction: string | null;
+  tel: string | null;
+  url: string | null;
+  postalCode: string | null;
+  address: string;
+  latitude: number;
+  longitude: number;
+  averageRating: number | null;
+  totalReviewCount: number | null;
+  rawDescription: string | null;
+};
+
+/** ====== 카테고리 한글 라벨 매핑 ====== */
+
+/** 대분류 */
+export const CATEGORY1_LABELS: Record<string, string> = {
+  PET_MEDICAL: '반려의료',
+  PET_TRAVEL: '반려동반여행',
+  PET_CAFE_RESTAURANT: '반려동물식당카페',
+  PET_SERVICE: '반려동물 서비스',
+  ETC: '기타',
+};
+
+/** 중분류 */
+export const CATEGORY2_LABELS: Record<string, string> = {
+  VET_PHARMACY: '동물약국',
+  MUSEUM: '박물관',
+  CAFE: '카페',
+  VET_HOSPITAL: '동물병원',
+  PET_SUPPLIES: '반려동물용품',
+  GROOMING: '미용',
+  ART_CENTER: '문예회관',
+  PENSION: '펜션',
+  RESTAURANT: '식당',
+  DESTINATION: '여행지',
+  DAYCARE: '위탁관리',
+  ART_MUSEUM: '미술관',
+  ETC: '기타',
+};
+
+/** 안전한 라벨 변환 함수 */
+export function getCategory1Label(v?: string | null) {
+  if (!v) return '-';
+  return CATEGORY1_LABELS[v] ?? v; // 매핑 없으면 원본 표시(방어)
+}
+
+export function getCategory2Label(v?: string | null) {
+  if (!v) return '-';
+  return CATEGORY2_LABELS[v] ?? v;
+}
+
+/** ====== API ====== */
+
 export async function searchPlaces(params: {
   lat: number;
   lon: number;
-  radiusKm: number;        
-  keyword?: string;        
-  category2?: string;      
+  radiusKm: number;     // km
+  keyword?: string;     // 선택
+  category?: string;    // 선택 (백엔드 파라미터 키와 일치: category2)
 }) {
   return api<ApiResponse<PlaceDto[]>>('/api/v1/places/search', { query: params });
 }
 
 export async function getPlaceDetail(placeId: number) {
-  return api<ApiResponse<any>>(`/api/v1/places/${placeId}`);
+  return api<ApiResponse<PlaceDetailResponse>>(`/api/v1/places/${placeId}`);
 }

--- a/frontend/app/search/placeService.ts
+++ b/frontend/app/search/placeService.ts
@@ -5,7 +5,7 @@ import { api } from '@/lib/api';
 export type PlaceDto = {
   id: number;
   name: string;
-  category2: string;        // 서버에서 enum name으로 옴 (e.g., VET_PHARMACY)
+  category2: string;        // 서버 enum name (e.g., VET_PHARMACY)
   latitude: number;
   longitude: number;
   distanceMeters: number;
@@ -69,10 +69,26 @@ export const CATEGORY2_LABELS: Record<string, string> = {
   ETC: '기타',
 };
 
+/** UI에서 쓸 카테고리 옵션(ETC 제외) */
+export const CATEGORY2_OPTIONS: { value: keyof typeof CATEGORY2_LABELS; label: string }[] = [
+  { value: 'VET_PHARMACY', label: CATEGORY2_LABELS.VET_PHARMACY },
+  { value: 'MUSEUM', label: CATEGORY2_LABELS.MUSEUM },
+  { value: 'CAFE', label: CATEGORY2_LABELS.CAFE },
+  { value: 'VET_HOSPITAL', label: CATEGORY2_LABELS.VET_HOSPITAL },
+  { value: 'PET_SUPPLIES', label: CATEGORY2_LABELS.PET_SUPPLIES },
+  { value: 'GROOMING', label: CATEGORY2_LABELS.GROOMING },
+  { value: 'ART_CENTER', label: CATEGORY2_LABELS.ART_CENTER },
+  { value: 'PENSION', label: CATEGORY2_LABELS.PENSION },
+  { value: 'RESTAURANT', label: CATEGORY2_LABELS.RESTAURANT },
+  { value: 'DESTINATION', label: CATEGORY2_LABELS.DESTINATION },
+  { value: 'DAYCARE', label: CATEGORY2_LABELS.DAYCARE },
+  { value: 'ART_MUSEUM', label: CATEGORY2_LABELS.ART_MUSEUM },
+];
+
 /** 안전한 라벨 변환 함수 */
 export function getCategory1Label(v?: string | null) {
   if (!v) return '-';
-  return CATEGORY1_LABELS[v] ?? v; // 매핑 없으면 원본 표시(방어)
+  return CATEGORY1_LABELS[v] ?? v;
 }
 
 export function getCategory2Label(v?: string | null) {
@@ -87,7 +103,7 @@ export async function searchPlaces(params: {
   lon: number;
   radiusKm: number;     // km
   keyword?: string;     // 선택
-  category?: string;    // 선택 (백엔드 파라미터 키와 일치: category2)
+  category2?: string;   // 선택 (백엔드 파라미터와 동일한 키)
 }) {
   return api<ApiResponse<PlaceDto[]>>('/api/v1/places/search', { query: params });
 }

--- a/frontend/app/search/placeService.ts
+++ b/frontend/app/search/placeService.ts
@@ -1,6 +1,5 @@
 import { api } from '@/lib/api';
 
-/** ====== 공용 타입 ====== */
 
 export type PlaceDto = {
   id: number;
@@ -19,7 +18,7 @@ export type ApiResponse<T> = {
   data: T;
 };
 
-/** ====== 상세 응답 타입 (백엔드 DTO와 동일) ====== */
+
 export type PlaceDetailResponse = {
   id: number;
   name: string;
@@ -41,7 +40,6 @@ export type PlaceDetailResponse = {
   rawDescription: string | null;
 };
 
-/** ====== 카테고리 한글 라벨 매핑 ====== */
 
 /** 대분류 */
 export const CATEGORY1_LABELS: Record<string, string> = {
@@ -69,7 +67,7 @@ export const CATEGORY2_LABELS: Record<string, string> = {
   ETC: '기타',
 };
 
-/** UI에서 쓸 카테고리 옵션(ETC 제외) */
+
 export const CATEGORY2_OPTIONS: { value: keyof typeof CATEGORY2_LABELS; label: string }[] = [
   { value: 'VET_PHARMACY', label: CATEGORY2_LABELS.VET_PHARMACY },
   { value: 'MUSEUM', label: CATEGORY2_LABELS.MUSEUM },
@@ -85,7 +83,7 @@ export const CATEGORY2_OPTIONS: { value: keyof typeof CATEGORY2_LABELS; label: s
   { value: 'ART_MUSEUM', label: CATEGORY2_LABELS.ART_MUSEUM },
 ];
 
-/** 안전한 라벨 변환 함수 */
+
 export function getCategory1Label(v?: string | null) {
   if (!v) return '-';
   return CATEGORY1_LABELS[v] ?? v;
@@ -96,7 +94,6 @@ export function getCategory2Label(v?: string | null) {
   return CATEGORY2_LABELS[v] ?? v;
 }
 
-/** ====== API ====== */
 
 export async function searchPlaces(params: {
   lat: number;

--- a/frontend/components/MapView.tsx
+++ b/frontend/components/MapView.tsx
@@ -5,7 +5,7 @@ import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
 import type { PlaceDto } from '@/app/search/placeService';
 import type { LatLngExpression } from 'leaflet';
 import L from 'leaflet';
-// app/globals.css에서 이미 'leaflet/dist/leaflet.css'를 import하므로 여기서는 생략
+
 
 type Props = {
   center: [number, number] | null; // 내 위치
@@ -13,7 +13,7 @@ type Props = {
   onSelectPlace?: (p: PlaceDto) => void;
 };
 
-/** center가 바뀔 때 지도만 이동 (MapContainer는 재마운트하지 않음) */
+
 function RecenterOnChange({ center }: { center: LatLngExpression }) {
   const map = useMap();
   useEffect(() => {
@@ -22,12 +22,12 @@ function RecenterOnChange({ center }: { center: LatLngExpression }) {
   return null;
 }
 
-/** SVG → data URL 유틸 */
+
 function svgToDataUrl(svg: string) {
   return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
 }
 
-/** 사용자 위치용 아이콘 (파란 핀) */
+
 const USER_SVG = `
 <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
@@ -42,7 +42,7 @@ const USER_SVG = `
 </svg>
 `;
 
-/** 장소 결과용 아이콘 (레드 핀) */
+
 const PLACE_SVG = `
 <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>

--- a/frontend/components/MapView.tsx
+++ b/frontend/components/MapView.tsx
@@ -1,51 +1,129 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
 import type { PlaceDto } from '@/app/search/placeService';
 import type { LatLngExpression } from 'leaflet';
+import L from 'leaflet';
+// app/globals.css에서 이미 'leaflet/dist/leaflet.css'를 import하므로 여기서는 생략
 
 type Props = {
-  center: [number, number] | null;
+  center: [number, number] | null; // 내 위치
   places: PlaceDto[];
   onSelectPlace?: (p: PlaceDto) => void;
 };
 
+/** center가 바뀔 때 지도만 이동 (MapContainer는 재마운트하지 않음) */
 function RecenterOnChange({ center }: { center: LatLngExpression }) {
   const map = useMap();
-  useEffect(() => { map.setView(center); }, [center, map]);
+  useEffect(() => {
+    map.setView(center);
+  }, [center, map]);
   return null;
 }
 
-export default function MapView({ center, places, onSelectPlace }: Props) {
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
-  if (!mounted) return null;
+/** SVG → data URL 유틸 */
+function svgToDataUrl(svg: string) {
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}
 
+/** 사용자 위치용 아이콘 (파란 핀) */
+const USER_SVG = `
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <filter id="shadow" x="-50%" y="-50%" width="200%" height="200%">
+      <feDropShadow dx="0" dy="2" stdDeviation="2" flood-opacity="0.25"/>
+    </filter>
+  </defs>
+  <g filter="url(#shadow)">
+    <path d="M24 44c0 0 14-12.5 14-22A14 14 0 1 0 10 22c0 9.5 14 22 14 22z" fill="#3B82F6"/>
+    <circle cx="24" cy="22" r="6.5" fill="white"/>
+  </g>
+</svg>
+`;
+
+/** 장소 결과용 아이콘 (레드 핀) */
+const PLACE_SVG = `
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <filter id="shadow2" x="-50%" y="-50%" width="200%" height="200%">
+      <feDropShadow dx="0" dy="2" stdDeviation="2" flood-opacity="0.25"/>
+    </filter>
+  </defs>
+  <g filter="url(#shadow2)">
+    <path d="M24 44c0 0 14-12.5 14-22A14 14 0 1 0 10 22c0 9.5 14 22 14 22z" fill="#EF4444"/>
+    <circle cx="24" cy="22" r="6.5" fill="white"/>
+  </g>
+</svg>
+`;
+
+const userIcon = L.icon({
+  iconUrl: svgToDataUrl(USER_SVG),
+  iconSize: [32, 32],
+  iconAnchor: [16, 32],   // 핀 끝이 좌표를 가리키도록
+  popupAnchor: [0, -28],
+});
+
+const placeIcon = L.icon({
+  iconUrl: svgToDataUrl(PLACE_SVG),
+  iconSize: [32, 32],
+  iconAnchor: [16, 32],
+  popupAnchor: [0, -28],
+});
+
+export default function MapView({ center, places, onSelectPlace }: Props) {
   const fallbackCenter: LatLngExpression = [37.5665, 126.9780]; // 서울시청
   const effectiveCenter: LatLngExpression = center ?? fallbackCenter;
 
-  return (
-    <MapContainer center={effectiveCenter} zoom={13} style={{ height: '400px', width: '100%' }}>
-      <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
-      <RecenterOnChange center={effectiveCenter} />
-
-      {center && <Marker position={effectiveCenter} />}
-
-      {places.map((p) => {
+  // 마커 배열 메모이제이션 (렌더 최적화)
+  const placeMarkers = useMemo(
+    () =>
+      places.map((p) => {
         const pos: LatLngExpression = [p.latitude, p.longitude];
         return (
-          <Marker key={p.id} position={pos} eventHandlers={{ click: () => onSelectPlace?.(p) }}>
+          <Marker
+            key={p.id}
+            position={pos}
+            icon={placeIcon}
+            eventHandlers={{ click: () => onSelectPlace?.(p) }}
+          >
             <Popup>
-              <div className="space-y-1.5">
+              <div className="space-y-1">
                 <div className="font-semibold">{p.name}</div>
-                <div className="text-xs text-muted-foreground">{p.address}</div>
-                <div className="text-xs">거리 {p.distanceMeters}m · 평점 {p.averageRating ?? "-"}</div>
+                <div className="text-xs">{p.address}</div>
+                <div className="text-xs">
+                  거리 {p.distanceMeters}m | 평점 {p.averageRating ?? '-'}
+                </div>
               </div>
             </Popup>
           </Marker>
         );
-      })}
+      }),
+    [places, onSelectPlace]
+  );
+
+  return (
+    <MapContainer
+      center={effectiveCenter}
+      zoom={13}
+      style={{ height: '400px', width: '100%' }}
+    >
+      <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+
+      {/* center가 바뀌면 부드럽게 이동 */}
+      <RecenterOnChange center={effectiveCenter} />
+
+      {/* 내 위치 마커 (위로 보이게 zIndexOffset) */}
+      {center && (
+        <Marker position={effectiveCenter} icon={userIcon} zIndexOffset={1000}>
+          <Popup>
+            <div className="text-sm">내 위치</div>
+          </Popup>
+        </Marker>
+      )}
+
+      {/* 검색 결과 마커들 */}
+      {placeMarkers}
     </MapContainer>
   );
 }

--- a/frontend/components/MapView.tsx
+++ b/frontend/components/MapView.tsx
@@ -4,58 +4,43 @@ import { useEffect, useState } from 'react';
 import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
 import type { PlaceDto } from '@/app/search/placeService';
 import type { LatLngExpression } from 'leaflet';
-// import 'leaflet/dist/leaflet.css';
 
 type Props = {
-  center: [number, number] | null; // 내 위치
+  center: [number, number] | null;
   places: PlaceDto[];
   onSelectPlace?: (p: PlaceDto) => void;
 };
 
-/** center가 바뀔 때 지도만 이동 (MapContainer 재마운트 금지) */
 function RecenterOnChange({ center }: { center: LatLngExpression }) {
   const map = useMap();
-  useEffect(() => {
-    map.setView(center);
-  }, [center, map]);
+  useEffect(() => { map.setView(center); }, [center, map]);
   return null;
 }
 
 export default function MapView({ center, places, onSelectPlace }: Props) {
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
-  if (!mounted) return null; // StrictMode/SSR 초기 중복 마운트 방지
+  if (!mounted) return null;
 
   const fallbackCenter: LatLngExpression = [37.5665, 126.9780]; // 서울시청
   const effectiveCenter: LatLngExpression = center ?? fallbackCenter;
 
   return (
-    <MapContainer
-      center={effectiveCenter}
-      zoom={13}
-      style={{ height: '400px', width: '100%' }}
-    >
+    <MapContainer center={effectiveCenter} zoom={13} style={{ height: '400px', width: '100%' }}>
       <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
-
       <RecenterOnChange center={effectiveCenter} />
 
-      {/* 내 위치 마커 */}
       {center && <Marker position={effectiveCenter} />}
 
-      {/* 검색 결과 마커 */}
       {places.map((p) => {
         const pos: LatLngExpression = [p.latitude, p.longitude];
         return (
-          <Marker
-            key={p.id}
-            position={pos}
-            eventHandlers={{ click: () => onSelectPlace?.(p) }}
-          >
+          <Marker key={p.id} position={pos} eventHandlers={{ click: () => onSelectPlace?.(p) }}>
             <Popup>
-              <div className="space-y-1">
+              <div className="space-y-1.5">
                 <div className="font-semibold">{p.name}</div>
-                <div className="text-xs">{p.address}</div>
-                <div className="text-xs">거리 {p.distanceMeters}m | 평점 {p.averageRating}</div>
+                <div className="text-xs text-muted-foreground">{p.address}</div>
+                <div className="text-xs">거리 {p.distanceMeters}m · 평점 {p.averageRating ?? "-"}</div>
               </div>
             </Popup>
           </Marker>

--- a/frontend/components/place-sidebar.tsx
+++ b/frontend/components/place-sidebar.tsx
@@ -373,4 +373,3 @@ export function PlaceSidebar({
     </>
   )
 }
-

--- a/frontend/components/place-sidebar.tsx
+++ b/frontend/components/place-sidebar.tsx
@@ -7,18 +7,71 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
-import { Star, Bookmark, X } from "lucide-react"
+import {
+  Star,
+  Bookmark,
+  X,
+  Loader2,
+  Clock4,
+  CalendarX2,
+  ParkingCircle,
+  PawPrint,
+  Phone,
+  Globe,
+  MapPin,
+  Hash,
+} from "lucide-react"
 import { useToast } from "@/hooks/use-toast"
 import type { Place, Review } from "@/lib/mock-data"
+import type { PlaceDetailResponse } from "@/app/search/placeService"
+import { getCategory1Label, getCategory2Label } from "@/app/search/placeService"
 
 interface PlaceSidebarProps {
   place: Place | null
   reviews: Review[]
   open: boolean
   onOpenChange: (open: boolean) => void
+  /** 상세 조회 결과를 부모에서 내려줌 */
+  detail?: PlaceDetailResponse | null
+  detailLoading?: boolean
 }
 
-export function PlaceSidebar({ place, reviews, open, onOpenChange }: PlaceSidebarProps) {
+function InfoRow({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: React.ReactNode
+}) {
+  return (
+    <div className="flex items-start gap-3 rounded-lg bg-muted/40 px-3 py-2">
+      <div className="mt-0.5 shrink-0 text-muted-foreground">{icon}</div>
+      <div className="min-w-0 flex-1">
+        <div className="text-xs text-muted-foreground">{label}</div>
+        <div className="truncate text-sm font-medium">{value}</div>
+      </div>
+    </div>
+  )
+}
+
+function BoolBadge({ on }: { on: boolean | null | undefined }) {
+  if (on === true)
+    return <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700">가능</span>
+  if (on === false)
+    return <span className="rounded-full bg-rose-100 px-2 py-0.5 text-xs font-medium text-rose-700">불가</span>
+  return <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">-</span>
+}
+
+export function PlaceSidebar({
+  place,
+  reviews,
+  open,
+  onOpenChange,
+  detail,
+  detailLoading,
+}: PlaceSidebarProps) {
   const [showReviewDialog, setShowReviewDialog] = useState(false)
   const [reviewContent, setReviewContent] = useState("")
   const [reviewRating, setReviewRating] = useState(0)
@@ -27,79 +80,45 @@ export function PlaceSidebar({ place, reviews, open, onOpenChange }: PlaceSideba
   const [localReviews, setLocalReviews] = useState<Review[]>(reviews)
   const { toast } = useToast()
 
-  // Track daily review points
+  // 로컬 포인트(모의)
   const [dailyPoints, setDailyPoints] = useState(0)
   const [reviewedPlacesToday, setReviewedPlacesToday] = useState<Set<string>>(new Set())
 
   const handleReviewSubmit = () => {
     if (reviewRating === 0) {
-      toast({
-        title: "별점 등록은 필수입니다",
-        variant: "destructive",
-      })
+      toast({ title: "별점 등록은 필수입니다", variant: "destructive" })
       return
     }
-
     if (reviewContent.length < 30) {
-      toast({
-        title: "본문은 30자 이상 작성 필수입니다",
-        variant: "destructive",
-      })
+      toast({ title: "본문은 30자 이상 작성 필수입니다", variant: "destructive" })
       return
     }
-
     if (reviewImage) {
       const validTypes = ["image/jpeg", "image/jpg", "image/png"]
       if (!validTypes.includes(reviewImage.type)) {
-        toast({
-          title: "지원하지 않는 파일 형식입니다",
-          variant: "destructive",
-        })
+        toast({ title: "지원하지 않는 파일 형식입니다", variant: "destructive" })
         return
       }
     }
-
-    // Check if already reviewed this place today
     if (place && reviewedPlacesToday.has(place.id)) {
-      toast({
-        title: "일일 한 장소의 리뷰 포인트 적립은 한번입니다.",
-        variant: "destructive",
-      })
-
-      // Still add the review, just no points
+      toast({ title: "일일 한 장소의 리뷰 포인트 적립은 한번입니다.", variant: "destructive" })
       addReview()
       return
     }
-
-    // Check daily limit
     const pointsToAdd = reviewImage ? 100 : 50
-
     if (dailyPoints + pointsToAdd > 1000) {
-      toast({
-        title: "일일 한도 1000p 적립으로 포인트는 제공 되지 않습니다.",
-        variant: "destructive",
-      })
+      toast({ title: "일일 한도 1000p 적립으로 포인트는 제공 되지 않습니다.", variant: "destructive" })
       addReview()
       return
     }
-
-    // Award points
     setDailyPoints((prev) => prev + pointsToAdd)
-    if (place) {
-      setReviewedPlacesToday((prev) => new Set(prev).add(place.id))
-    }
-
-    toast({
-      title: "리뷰 등록 완료",
-      description: `${pointsToAdd}포인트가 적립되었습니다!`,
-    })
-
+    if (place) setReviewedPlacesToday((prev) => new Set(prev).add(place.id))
+    toast({ title: "리뷰 등록 완료", description: `${pointsToAdd}포인트가 적립되었습니다!` })
     addReview()
   }
 
   const addReview = () => {
     if (!place) return
-
     const newReview: Review = {
       id: `new-${Date.now()}`,
       placeId: place.id,
@@ -110,7 +129,6 @@ export function PlaceSidebar({ place, reviews, open, onOpenChange }: PlaceSideba
       image: reviewImage ? URL.createObjectURL(reviewImage) : undefined,
       date: new Date().toISOString().split("T")[0],
     }
-
     setLocalReviews([newReview, ...localReviews])
     setShowReviewDialog(false)
     setReviewContent("")
@@ -118,91 +136,193 @@ export function PlaceSidebar({ place, reviews, open, onOpenChange }: PlaceSideba
     setReviewImage(null)
   }
 
-  if (!place) return null
+  if (!place && !detail) return null
+
+  // 제목, 카테고리, 주소, 평점/리뷰수 구성
+  const title = detail?.name ?? place?.name ?? ""
+  const categoryLabel = detail
+    ? `${getCategory1Label(detail.category1)} / ${getCategory2Label(detail.category2)}`
+    : (place?.category ?? "")
+  const address = detail?.address ?? place?.address ?? ""
+  const rating = (detail?.averageRating ?? place?.rating ?? 0) as number
+  const reviewCount = detail?.totalReviewCount
+
+  const dash = (s?: string | null) => (s && s.trim() ? s : "-")
 
   return (
     <>
-      <Card className={`${open ? "block" : "hidden lg:block"} sticky top-6 h-[calc(100vh-120px)] overflow-y-auto`}>
-        <CardHeader className="flex flex-row items-start justify-between">
-          <div className="flex-1">
-            <CardTitle className="text-balance">{place.name}</CardTitle>
-            <p className="text-sm text-muted-foreground">{place.category}</p>
-          </div>
-          <div className="flex gap-2">
-            <Button variant="ghost" size="icon" onClick={() => setBookmarked(!bookmarked)}>
-              <Bookmark className={bookmarked ? "fill-primary" : ""} />
-            </Button>
-            <Button variant="ghost" size="icon" className="lg:hidden" onClick={() => onOpenChange(false)}>
-              <X />
-            </Button>
-          </div>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <img
-            src={place.image || "/placeholder.svg"}
-            alt={place.name}
-            className="h-48 w-full rounded-lg object-cover"
-          />
-
-          <div>
-            <p className="text-sm text-pretty">{place.description}</p>
-            <p className="mt-1 text-sm text-muted-foreground">{place.address}</p>
+      <Card
+        className={`${open ? "block" : "hidden lg:block"} sticky top-6 h-[calc(100vh-120px)] overflow-y-auto rounded-2xl`}
+      >
+        {/* 헤더 */}
+        <CardHeader className="flex flex-row items-start justify-between gap-3">
+          <div className="min-w-0">
+            <CardTitle className="text-balance text-xl">{title}</CardTitle>
+            <p className="mt-1 line-clamp-1 text-sm text-muted-foreground">{categoryLabel}</p>
+            <p className="mt-1 line-clamp-2 text-xs text-muted-foreground flex items-center gap-1">
+              <MapPin className="h-3.5 w-3.5" />
+              {address}
+            </p>
             <div className="mt-2 flex items-center gap-1">
               {Array.from({ length: 5 }).map((_, i) => (
                 <Star
                   key={i}
-                  className={`h-4 w-4 ${i < Math.floor(place.rating) ? "fill-secondary text-secondary" : "text-muted"}`}
+                  className={`h-4 w-4 ${i < Math.floor(rating) ? "fill-secondary text-secondary" : "text-muted"}`}
                 />
               ))}
-              <span className="ml-1 text-sm">{place.rating}</span>
+              <span className="ml-1 text-sm font-medium">{rating ? rating.toFixed(1) : "-"}</span>
+              {typeof reviewCount === "number" && (
+                <span className="text-xs text-muted-foreground">· 리뷰 {reviewCount}개</span>
+              )}
             </div>
           </div>
+          <div className="flex shrink-0 gap-2">
+            <Button variant="ghost" size="icon" onClick={() => setBookmarked(!bookmarked)} className="rounded-full">
+              <Bookmark className={bookmarked ? "fill-primary" : ""} />
+            </Button>
+            <Button variant="ghost" size="icon" className="rounded-full lg:hidden" onClick={() => onOpenChange(false)}>
+              <X />
+            </Button>
+          </div>
+        </CardHeader>
 
-          <Button onClick={() => setShowReviewDialog(true)} className="w-full">
-            리뷰 등록
-          </Button>
+        {/* 구분선 */}
+        <div className="mx-6 h-px bg-border" />
 
-          <div className="space-y-3">
-            <h3 className="font-semibold">리뷰</h3>
+        {/* 콘텐츠 */}
+        <CardContent className="space-y-6 py-6">
+          {/* 이미지/설명(모크 유지) */}
+          {place?.image && (
+            <img
+              src={place.image || "/placeholder.svg"}
+              alt={title}
+              className="h-44 w-full rounded-xl object-cover"
+            />
+          )}
+          {place?.description && (
+            <p className="text-sm leading-relaxed text-pretty">{place.description}</p>
+          )}
+
+          {/* 상세 정보 */}
+          <section className="space-y-3">
+            <h3 className="text-sm font-semibold">상세 정보</h3>
+
+            {detailLoading ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                불러오는 중…
+              </div>
+            ) : detail ? (
+              <div className="grid gap-2">
+                <InfoRow icon={<Clock4 className="h-4 w-4" />} label="영업시간" value={dash(detail.openingHours)} />
+                <InfoRow icon={<CalendarX2 className="h-4 w-4" />} label="휴무일" value={dash(detail.closedDays)} />
+                <InfoRow
+                  icon={<ParkingCircle className="h-4 w-4" />}
+                  label="주차"
+                  value={<BoolBadge on={detail.parking} />}
+                />
+                <InfoRow
+                  icon={<PawPrint className="h-4 w-4" />}
+                  label="반려동물 동반"
+                  value={
+                    <div className="flex items-center gap-2">
+                      <BoolBadge on={detail.petAllowed} />
+                      <span className="text-xs text-muted-foreground">{dash(detail.petRestriction)}</span>
+                    </div>
+                  }
+                />
+                <InfoRow
+                  icon={<Phone className="h-4 w-4" />}
+                  label="전화번호"
+                  value={
+                    detail.tel ? (
+                      <a className="underline underline-offset-2" href={`tel:${detail.tel}`}>
+                        {detail.tel}
+                      </a>
+                    ) : (
+                      "-"
+                    )
+                  }
+                />
+                <InfoRow
+                  icon={<Globe className="h-4 w-4" />}
+                  label="웹사이트"
+                  value={
+                    detail.url ? (
+                      <a className="truncate underline underline-offset-2" href={detail.url} target="_blank" rel="noreferrer">
+                        {detail.url}
+                      </a>
+                    ) : (
+                      "-"
+                    )
+                  }
+                />
+                <InfoRow icon={<Hash className="h-4 w-4" />} label="우편번호" value={dash(detail.postalCode)} />
+                {/* 원본 설명 */}
+                {detail.rawDescription && (
+                  <div className="rounded-lg bg-muted/40 px-3 py-2">
+                    <div className="mb-1 text-xs text-muted-foreground">원본 설명</div>
+                    <div className="whitespace-pre-wrap text-xs text-muted-foreground">{detail.rawDescription}</div>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">상세 정보를 불러오지 못했습니다.</p>
+            )}
+          </section>
+
+          {/* 리뷰 작성 버튼 */}
+          <section className="space-y-2">
+            <Button onClick={() => setShowReviewDialog(true)} className="w-full rounded-xl">
+              리뷰 등록
+            </Button>
+          </section>
+
+          {/* 리뷰 리스트 */}
+          <section className="space-y-3">
+            <h3 className="text-sm font-semibold">리뷰</h3>
             {localReviews.length === 0 ? (
               <p className="text-sm text-muted-foreground">아직 리뷰가 없습니다.</p>
             ) : (
-              localReviews.map((review) => (
-                <Card key={review.id}>
-                  <CardContent className="p-4">
-                    {review.image && (
-                      <img
-                        src={review.image || "/placeholder.svg"}
-                        alt="리뷰 이미지"
-                        className="mb-2 h-32 w-full rounded object-cover"
-                      />
-                    )}
-                    <p className="text-sm text-pretty">{review.content}</p>
-                    <div className="mt-2 flex items-center gap-1">
-                      {Array.from({ length: 5 }).map((_, i) => (
-                        <Star
-                          key={i}
-                          className={`h-3 w-3 ${i < review.rating ? "fill-secondary text-secondary" : "text-muted"}`}
+              <div className="space-y-3">
+                {localReviews.map((review) => (
+                  <Card key={review.id} className="rounded-xl">
+                    <CardContent className="space-y-2 p-4">
+                      {review.image && (
+                        <img
+                          src={review.image || "/placeholder.svg"}
+                          alt="리뷰 이미지"
+                          className="h-32 w-full rounded-lg object-cover"
                         />
-                      ))}
-                    </div>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      {review.userName} · {review.date}
-                    </p>
-                  </CardContent>
-                </Card>
-              ))
+                      )}
+                      <p className="text-sm leading-relaxed text-pretty">{review.content}</p>
+                      <div className="flex items-center gap-1">
+                        {Array.from({ length: 5 }).map((_, i) => (
+                          <Star
+                            key={i}
+                            className={`h-3.5 w-3.5 ${i < review.rating ? "fill-secondary text-secondary" : "text-muted"}`}
+                          />
+                        ))}
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        {review.userName} · {review.date}
+                      </p>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
             )}
-          </div>
+          </section>
         </CardContent>
       </Card>
 
+      {/* 리뷰 작성 다이얼로그 */}
       <Dialog open={showReviewDialog} onOpenChange={setShowReviewDialog}>
-        <DialogContent>
+        <DialogContent className="sm:max-w-lg">
           <DialogHeader>
             <DialogTitle>리뷰 작성</DialogTitle>
           </DialogHeader>
-          <div className="space-y-4">
+          <div className="space-y-5">
             <div className="space-y-2">
               <Label>별점 (필수)</Label>
               <div className="flex gap-1">
@@ -227,11 +347,7 @@ export function PlaceSidebar({ place, reviews, open, onOpenChange }: PlaceSideba
 
             <div className="space-y-2">
               <Label>이미지 (선택)</Label>
-              <Input
-                type="file"
-                accept="image/jpeg,image/jpg,image/png"
-                onChange={(e) => setReviewImage(e.target.files?.[0] || null)}
-              />
+              <Input type="file" accept="image/jpeg,image/jpg,image/png" onChange={(e) => setReviewImage(e.target.files?.[0] || null)} />
             </div>
 
             <div className="flex gap-2">
@@ -257,3 +373,4 @@ export function PlaceSidebar({ place, reviews, open, onOpenChange }: PlaceSideba
     </>
   )
 }
+

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,6 +1,7 @@
-const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL!;
+// 로컬 전용: 환경변수 없이 바로 백엔드 호출
+const BASE_URL = "http://localhost:8080";
 
-type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 
 export async function api<T>(
   path: string,
@@ -8,29 +9,31 @@ export async function api<T>(
     method?: HttpMethod;
     query?: Record<string, string | number | boolean | undefined>;
     token?: string;
+    body?: unknown; // 필요 시 확장
   } = {}
 ): Promise<T> {
-  const { method = 'GET', query, token } = options;
+  const { method = "GET", query, token, body } = options;
 
   const qs = query
-    ? '?' +
+    ? "?" +
       Object.entries(query)
         .filter(([, v]) => v !== undefined)
         .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
-        .join('&')
-    : '';
+        .join("&")
+    : "";
 
   const res = await fetch(`${BASE_URL}${path}${qs}`, {
     method,
     headers: {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
-    credentials: 'include',
+    credentials: "include", // 쿠키 인증 사용 시 유지
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
   });
 
   if (!res.ok) {
-    const text = await res.text().catch(() => '');
+    const text = await res.text().catch(() => "");
     throw new Error(`API ${res.status}: ${text || res.statusText}`);
   }
   return res.json() as Promise<T>;


### PR DESCRIPTION
## 📌 관련 이슈
- close #123 

## 📝 변경 사항
### AS-IS
- 상세 조회 시 주소 및 일부 필드만 표시
- 지도 마커 단일 형태로 표시 (사용자 위치 구분 불가)
- 백엔드 검색 결과 100개 제한

### TO-BE
- PlaceDetailResponse의 모든 필드 표시 (영업시간, 휴무일, 주차, 반려동물 동반 여부 등)
- 사용자 위치 마커(파란색) + 검색 결과 마커(빨간색) 구분 표시
- 백엔드 검색 결과 수 300개로 확장
- 페이징 구조 도입 고려를 위한 코드 정리

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 처음 검색탭 들어갔을때 현재 사용자의 위치를 파란색 마커를 사용해서 표시
<img width="2520" height="1600" alt="image" src="https://github.com/user-attachments/assets/e6828ab3-7123-4002-bc6e-36c815e56727" />

- 반경 검색을 통해 해당하는 장소들을 빨간색 마커를 사용해서 표시
<img width="2400" height="1614" alt="image" src="https://github.com/user-attachments/assets/8ebe9cb6-01e6-4c16-83f0-3eac487f34f0" />

- 지도에서 하나의 장소를 클릭하면 장소 상세 조회로 이동(상세 정보 내용 추가 및 ui 개선)
<img width="2806" height="1536" alt="image" src="https://github.com/user-attachments/assets/b40319ed-2362-468c-bce9-e24a1ee65507" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 현재는 검색 결과를 300개로 확장해두었으나, 추후 페이징 처리 방식 도입 예정입니다.