### PR TITLE
[Feature] [FE] 로그인 API 연결, 토큰 세션 스토리지에 저장 + 회원가입 이메일 중복 확인 버튼 추가

### DIFF
--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -44,9 +44,6 @@ export default function LoginPage() {
       if (response.ok && data.code === "200") {
         const token = data.data.token
 
-        // 1️⃣ 세션 스토리지에 토큰 저장
-        sessionStorage.setItem("authToken", token)
-
         setAuthToken(token)
 
         toast({

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import type React from "react"
-
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
@@ -15,10 +14,11 @@ import { useToast } from "@/hooks/use-toast"
 export default function LoginPage() {
   const [username, setUsername] = useState("")
   const [password, setPassword] = useState("")
+  const [loading, setLoading] = useState(false)
   const router = useRouter()
   const { toast } = useToast()
 
-  const handleLogin = (e: React.FormEvent) => {
+  const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()
 
     if (!username || !password) {
@@ -30,59 +30,87 @@ export default function LoginPage() {
       return
     }
 
-    // Mock login - in real app, validate with backend
-    setAuthToken("mock-token-" + username)
-    toast({
-      title: "로그인 성공",
-      description: "환영합니다!",
-    })
-    router.push("/")
+    setLoading(true)
+
+    try {
+      const response = await fetch("http://localhost:8080/api/v1/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ nickName: username, password }), // ✅ 백엔드 요청에 맞게 변경
+      })
+
+      const data = await response.json()
+
+      if (response.ok && data.code === "200") {
+        const token = data.data.token
+        setAuthToken(token)
+        toast({
+          title: "로그인 성공",
+          description: "환영합니다!",
+        })
+        router.push("/")
+      } else {
+        toast({
+          title: "로그인 실패",
+          description: data.message || "아이디 또는 비밀번호가 틀렸습니다.",
+          variant: "destructive",
+        })
+      }
+    } catch (error: any) {
+      toast({
+        title: "네트워크 오류",
+        description: error.message || "로그인 중 오류가 발생했습니다.",
+        variant: "destructive",
+      })
+    } finally {
+      setLoading(false)
+    }
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background px-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <CardTitle className="text-3xl font-bold text-primary">Petplace</CardTitle>
-          <CardDescription>반려동물 종합 플랫폼에 오신 것을 환영합니다</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleLogin} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="username">아이디</Label>
-              <Input
-                id="username"
-                type="text"
-                value={username}
-                onChange={(e) => setUsername(e.target.value)}
-                placeholder="아이디를 입력하세요"
-              />
-            </div>
+      <div className="flex min-h-screen items-center justify-center bg-background px-4">
+        <Card className="w-full max-w-md">
+          <CardHeader className="text-center">
+            <CardTitle className="text-3xl font-bold text-primary">Petplace</CardTitle>
+            <CardDescription>반려동물 종합 플랫폼에 오신 것을 환영합니다</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleLogin} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="username">아이디</Label>
+                <Input
+                    id="username"
+                    type="text"
+                    value={username}
+                    onChange={(e) => setUsername(e.target.value)}
+                    placeholder="아이디를 입력하세요"
+                />
+              </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="password">비밀번호</Label>
-              <Input
-                id="password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                placeholder="비밀번호를 입력하세요"
-              />
-            </div>
+              <div className="space-y-2">
+                <Label htmlFor="password">비밀번호</Label>
+                <Input
+                    id="password"
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="비밀번호를 입력하세요"
+                />
+              </div>
 
-            <Button type="submit" className="w-full">
-              로그인
-            </Button>
+              <Button type="submit" className="w-full" disabled={loading}>
+                {loading ? "로그인 중..." : "로그인"}
+              </Button>
 
-            <div className="text-center text-sm">
-              <span className="text-muted-foreground">계정이 없으신가요? </span>
-              <Link href="/signup" className="text-primary hover:underline">
-                회원가입
-              </Link>
-            </div>
-          </form>
-        </CardContent>
-      </Card>
-    </div>
+              <div className="text-center text-sm">
+                <span className="text-muted-foreground">계정이 없으신가요? </span>
+                <Link href="/signup" className="text-primary hover:underline">
+                  회원가입
+                </Link>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
   )
 }

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -43,7 +43,12 @@ export default function LoginPage() {
 
       if (response.ok && data.code === "200") {
         const token = data.data.token
+
+        // 1️⃣ 세션 스토리지에 토큰 저장
+        sessionStorage.setItem("authToken", token)
+
         setAuthToken(token)
+
         toast({
           title: "로그인 성공",
           description: "환영합니다!",

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -37,6 +37,10 @@ export default function SignupPage() {
   const [usernameAvailable, setUsernameAvailable] = useState(false)
   const [checkingUsername, setCheckingUsername] = useState(false)
 
+  const [emailChecked, setEmailChecked] = useState(false)
+  const [emailAvailable, setEmailAvailable] = useState(false)
+  const [checkingEmail, setCheckingEmail] = useState(false)
+
   const [emailVerified, setEmailVerified] = useState(false)
   const [codeSent, setCodeSent] = useState(false)
   const [sendingCode, setSendingCode] = useState(false)
@@ -52,6 +56,50 @@ export default function SignupPage() {
     hasSpecial: false,
   })
 
+// 이메일 중복 확인 함수
+  const checkEmailDuplicate = async () => {
+    const fullEmail = `${emailLocal}@${emailDomain === "custom" ? customDomain : emailDomain}`
+
+    if (!emailLocal || (emailDomain === "custom" && !customDomain)) {
+      toast({
+        title: "입력 오류",
+        description: "이메일을 입력해주세요.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    setCheckingEmail(true)
+    try {
+      const response = await fetch(
+          `http://localhost:8080/api/v1/signup-email?email=${encodeURIComponent(fullEmail)}`,
+          { method: "GET", headers: { "Content-Type": "application/json" } }
+      )
+      const data = await response.json()
+
+      if (response.ok && data.code === "200" && data.data?.result === true) {
+        setEmailChecked(true)
+        setEmailAvailable(true)
+        toast({ title: "사용 가능", description: "사용 가능한 이메일입니다." })
+      } else {
+        setEmailChecked(true)
+        setEmailAvailable(false)
+        toast({
+          title: "중복된 이메일",
+          description: data.message || "이미 사용 중인 이메일입니다.",
+          variant: "destructive",
+        })
+      }
+    } catch (error: any) {
+      toast({
+        title: "네트워크 오류",
+        description: error.message || "이메일 확인 중 오류가 발생했습니다.",
+        variant: "destructive",
+      })
+    } finally {
+      setCheckingEmail(false)
+    }
+  }
   const validatePassword = (pwd: string) => {
     setPasswordValidation({ //🚨 영어, 숫자, 특수문자, 길이 체크함
       length: pwd.length >= 8 && pwd.length <= 12,
@@ -476,6 +524,18 @@ export default function SignupPage() {
                           placeholder="도메인 입력"
                           required
                       />
+                  )}
+                  {/* ✅ 이메일 중복 확인 버튼 추가 */}
+                  {!emailVerified && (
+                      <Button
+                          type="button"
+                          variant="outline"
+                          onClick={checkEmailDuplicate}
+                          disabled={checkingEmail || !emailLocal || (emailDomain === "custom" && !customDomain)}
+                          className="w-full"
+                      >
+                        {checkingEmail ? "확인 중..." : "이메일 중복 확인"}
+                      </Button>
                   )}
                   {!emailVerified && (
                       <div className="space-y-2">

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -1,16 +1,16 @@
 export function getAuthToken(): string | null {
   if (typeof window === "undefined") return null
-  return localStorage.getItem("authToken")
+  return sessionStorage.getItem("authToken")
 }
 
 export function setAuthToken(token: string): void {
   if (typeof window === "undefined") return
-  localStorage.setItem("authToken", token)
+  sessionStorage.setItem("authToken", token)
 }
 
 export function removeAuthToken(): void {
   if (typeof window === "undefined") return
-  localStorage.removeItem("authToken")
+  sessionStorage.removeItem("authToken")
 }
 
 export function isAuthenticated(): boolean {


### PR DESCRIPTION
## 📌 관련 이슈
- close #127 

## 📝 변경 사항
### AS-IS
- 사용자가 로그인을 할 수 없음(백엔드와 프론트 API 미연결)
- 로그인 성공시, 토큰이 세션 스토리지에 저장이 안됨
- 사용자가 바로 이메일 중복 확인을 할 수 없음

### TO-BE
- 백엔드 API 명세서에 맞게 프론트 코드 수정(상태코드, API 주소 등)
- sessionStorage.setItem() 을 사용하여 로그인 성공시, 논의한 대로 토큰을 세션스토리지에 저장
- 회원가입 페이지에 이메일 버튼을 추가하여 바로 중복 확인을 가능하게 함

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
**최종 회원가입 페이지(이메일 중복 확인 버튼 추가)**
<img width="300" height="450" alt="스크린샷 2025-10-24 114556" src="https://github.com/user-attachments/assets/42b8d6ed-589b-40fe-9780-68971d19c968" />
**로그인 실패 모습**
<img width="470" height="390" alt="스크린샷 2025-10-24 115804" src="https://github.com/user-attachments/assets/b4206bf3-a462-4819-945e-54ab3f9cad50" />
**로그인 후, 세션 스토리지에 토큰이 저장된 모습**
<img width="800" height="470" alt="스크린샷 2025-10-24 122734" src="https://github.com/user-attachments/assets/709d82c4-475d-4f87-873a-9bff15b18d3d" />

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
~~login의 page.tsx를 보시면 이런식으로 세션 스토리지에 토큰을 저장하는 코드를 넣었습니다.~~

~~토큰을 사용하실 땐 이렇게 사용하면 된다고 하니, 참고바랍니다.~~

---

**수정**
- 살펴보니 이미 V0.app이 `frontend > lib > auth.ts` 파일 안에 로컬스토리지에 저장을 하는 로직을 만들어놔서 로컬, 세션 2곳에 토큰이 저장되는 문제를 발견하였습니다.
- 그래서 auth.ts에서 로컬 -> 세션으로 바꿨습니다.(수정하고 로컬테스트로 세션에만 토큰 저장되는 거 확인함)
- 사용하시려면 아래 예시처럼 사용하시면 되세요~ (몇몇페이지는 v0가 이미 넣어준 것 같아요)
```javascript
import { getAuthToken } from "@/lib/auth" // auth.ts 파일 임포트

getAuthToken()
```
*한 번에 문제없이 하고 싶은데 잘 안되네요,,, 번거롭게 해서 죄송합니다,,*
