### PR TITLE
[Fix] 리뷰 목록 이미지 미표시 및 마이페이지 리뷰 목록 이미지 미표시 해결

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/mypage/dto/response/MyPageResponse.java
+++ b/backend/src/main/java/com/backend/petplace/domain/mypage/dto/response/MyPageResponse.java
@@ -3,33 +3,22 @@ package com.backend.petplace.domain.mypage.dto.response;
 import com.backend.petplace.domain.mypage.dto.MyPageUserInfo;
 import com.backend.petplace.domain.mypage.dto.MyPageUserPets;
 import com.backend.petplace.domain.mypage.dto.MyPageUserPoints;
-import com.backend.petplace.domain.mypage.dto.MyPageUserReviews;
-import com.backend.petplace.domain.pet.entity.Pet;
-import com.backend.petplace.domain.point.entity.Point;
-import com.backend.petplace.domain.review.entity.Review;
-import com.backend.petplace.domain.user.entity.User;
+import com.backend.petplace.domain.review.dto.response.MyReviewResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Builder
+@RequiredArgsConstructor
 @Schema(description = "마이페이지 조회용 API")
 public class MyPageResponse {
 
   private final MyPageUserInfo userInfo;
-  private final List<MyPageUserReviews> reviews;
+  private final List<MyReviewResponse> reviews;
   private final List<MyPageUserPoints> points;
   private final List<MyPageUserPets> pets;
-
-  public MyPageResponse(MyPageUserInfo userInfo, List<MyPageUserReviews> reviews,
-      List<MyPageUserPoints> points, List<MyPageUserPets> pets) {
-    this.userInfo = userInfo;
-    this.reviews = reviews;
-    this.points = points;
-    this.pets = pets;
-  }
-
 
 }

--- a/backend/src/main/java/com/backend/petplace/domain/mypage/service/MyPageService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/mypage/service/MyPageService.java
@@ -3,15 +3,13 @@ package com.backend.petplace.domain.mypage.service;
 import com.backend.petplace.domain.mypage.dto.MyPageUserInfo;
 import com.backend.petplace.domain.mypage.dto.MyPageUserPets;
 import com.backend.petplace.domain.mypage.dto.MyPageUserPoints;
-import com.backend.petplace.domain.mypage.dto.MyPageUserReviews;
 import com.backend.petplace.domain.mypage.dto.response.MyPageResponse;
-import com.backend.petplace.domain.pet.entity.Pet;
 import com.backend.petplace.domain.pet.repository.PetRepository;
-import com.backend.petplace.domain.point.entity.Point;
 import com.backend.petplace.domain.point.repository.PointRepository;
 import com.backend.petplace.domain.point.type.PointPolicy;
-import com.backend.petplace.domain.review.entity.Review;
+import com.backend.petplace.domain.review.dto.response.MyReviewResponse;
 import com.backend.petplace.domain.review.repository.ReviewRepository;
+import com.backend.petplace.domain.review.service.S3Service;
 import com.backend.petplace.domain.user.entity.User;
 import com.backend.petplace.domain.user.repository.UserRepository;
 import com.backend.petplace.global.exception.BusinessException;
@@ -30,19 +28,30 @@ public class MyPageService {
   private final PointRepository pointRepository;
   private final ReviewRepository reviewRepository;
   private final PetRepository petRepository;
+  private final S3Service s3Service;
 
   @Transactional(readOnly = true)
-  public MyPageResponse myPage(Long userId){
+  public MyPageResponse myPage(Long userId) {
 
-    User user = userRepository.findById(userId).orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEMBER));
-    int earnablePoints = Math.max(PointPolicy.DAILY_LIMIT.getValue() - pointRepository.findTodaysPointsSumByUser(user, LocalDate.now()), 0); //음수면 0으로 자동 설정\
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEMBER));
+    int earnablePoints = Math.max(
+        PointPolicy.DAILY_LIMIT.getValue() - pointRepository.findTodaysPointsSumByUser(user,
+            LocalDate.now()), 0); //음수면 0으로 자동 설정\
 
     List<MyPageUserPoints> pointDto = pointRepository.findMyPagePointHistory(user);
-    List<MyPageUserReviews> reviewDto = reviewRepository.findByUserWithPlace(user);
+    List<MyReviewResponse> reviewDtoWithS3Path = reviewRepository.findMyReviewsWithProjection(user);
+
+    List<MyReviewResponse> reviewDto = reviewDtoWithS3Path.stream()
+        .map(dto -> MyReviewResponse.withFullImageUrl(
+            dto,
+            s3Service.getPublicUrl(dto.getImageUrl())
+        ))
+        .toList();
+
     List<MyPageUserPets> petDto = petRepository.findByUserWithActivatedPet(user);
     MyPageUserInfo userDto = MyPageUserInfo.from(user, earnablePoints, reviewDto.size());
 
     return new MyPageResponse(userDto, reviewDto, pointDto, petDto);
   }
-
 }

--- a/backend/src/main/java/com/backend/petplace/domain/point/dto/PlaceInfo.java
+++ b/backend/src/main/java/com/backend/petplace/domain/point/dto/PlaceInfo.java
@@ -1,5 +1,6 @@
 package com.backend.petplace.domain.point.dto;
 
+import com.backend.petplace.domain.place.entity.Place;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
@@ -16,9 +17,21 @@ public class PlaceInfo {
   @Schema(description = "장소 전체 주소 -  우편번호 제외", example = "서울 강남구 테헤란로 123")
   private String fullAddress;
 
-  public PlaceInfo(Long placeId, String placeName, String address) {
+  PlaceInfo(Long placeId, String placeName, String address) {
     this.placeId = placeId;
     this.placeName = placeName;
     this.fullAddress = address;
+  }
+
+  public static PlaceInfo fromProjection(Long placeId, String placeName, String address) {
+    return new PlaceInfo(placeId, placeName, address);
+  }
+
+  public static PlaceInfo from(Place place) {
+    return new PlaceInfo(
+        place.getId(),
+        place.getName(),
+        place.getAddress()
+    );
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/review/dto/ReviewInfo.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/dto/ReviewInfo.java
@@ -1,6 +1,5 @@
 package com.backend.petplace.domain.review.dto;
 
-import com.backend.petplace.domain.review.entity.Review;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/backend/src/main/java/com/backend/petplace/domain/review/dto/ReviewInfo.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/dto/ReviewInfo.java
@@ -29,12 +29,27 @@ public class ReviewInfo {
   @Schema(description = "작성일", example = "2025-10-15")
   private LocalDate createdDate;
 
-  public ReviewInfo(Long reviewId, String userName, String content, int rating, String imageUrl, LocalDateTime createdDate) {
+  public ReviewInfo(Long reviewId, String userName, String content, int rating, String imageUrl,
+      LocalDateTime createdDate) {
     this.reviewId = reviewId;
     this.userName = userName;
     this.content = content;
     this.rating = rating;
     this.imageUrl = imageUrl;
     this.createdDate = createdDate.toLocalDate();
+  }
+
+  // S3 경로를 전체 URL로 교체하는 생성자
+  private ReviewInfo(ReviewInfo dto, String fullImageUrl) {
+    this.reviewId = dto.reviewId;
+    this.userName = dto.userName;
+    this.content = dto.content;
+    this.rating = dto.rating;
+    this.createdDate = dto.createdDate;
+    this.imageUrl = fullImageUrl;
+  }
+
+  public static ReviewInfo withFullImageUrl(ReviewInfo dto, String fullImageUrl) {
+    return new ReviewInfo(dto, fullImageUrl);
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/review/dto/response/MyReviewResponse.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/dto/response/MyReviewResponse.java
@@ -33,13 +33,30 @@ public class MyReviewResponse {
   @Schema(description = "해당 리뷰로 적립된 포인트", example = "100")
   private int pointsAwarded;
 
-  public MyReviewResponse(Long reviewId, Long placeId, String placeName, String placeAddress, int rating, String content, String imageUrl, LocalDateTime createdDate, Integer pointsAwarded) {
+  public MyReviewResponse(Long reviewId, Long placeId, String placeName, String placeAddress,
+      int rating, String content, String imageUrl, LocalDateTime createdDate,
+      Integer pointsAwarded) {
     this.reviewId = reviewId;
-    this.place = new PlaceInfo(placeId, placeName, placeAddress);
+    this.place = PlaceInfo.fromProjection(placeId, placeName, placeAddress);
     this.rating = rating;
     this.content = content;
     this.imageUrl = imageUrl;
     this.createdDate = createdDate.toLocalDate();
     this.pointsAwarded = (pointsAwarded != null) ? pointsAwarded : 0;
+  }
+
+  // S3 경로를 전체 URL로 교체하는 생성자
+  private MyReviewResponse(MyReviewResponse dto, String fullImageUrl) {
+    this.reviewId = dto.reviewId;
+    this.place = dto.place;
+    this.rating = dto.rating;
+    this.content = dto.content;
+    this.createdDate = dto.createdDate;
+    this.pointsAwarded = dto.pointsAwarded;
+    this.imageUrl = fullImageUrl;
+  }
+
+  public static MyReviewResponse withFullImageUrl(MyReviewResponse dto, String fullImageUrl) {
+    return new MyReviewResponse(dto, fullImageUrl);
   }
 }

--- a/backend/src/main/java/com/backend/petplace/domain/review/entity/Review.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/entity/Review.java
@@ -1,15 +1,18 @@
 package com.backend.petplace.domain.review.entity;
 
 import com.backend.petplace.domain.place.entity.Place;
+import com.backend.petplace.domain.point.entity.Point;
 import com.backend.petplace.domain.user.entity.User;
 import com.backend.petplace.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,6 +35,9 @@ public class Review extends BaseEntity {
   @ManyToOne
   @JoinColumn(name = "placeId", nullable = false)
   private Place place;
+
+  @OneToOne(mappedBy = "review", fetch = FetchType.LAZY)
+  private Point point;
 
   @Column(nullable = false)
   private int rating;

--- a/backend/src/main/java/com/backend/petplace/domain/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/repository/ReviewRepository.java
@@ -40,4 +40,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
   "JOIN r.place p " +
   "WHERE r.user = :user ORDER BY r.id DESC")
   List<MyPageUserReviews> findByUserWithPlace(@Param("user") User user);
+
+  List<Review> findAllByPlace(Place place);
 }

--- a/backend/src/main/java/com/backend/petplace/domain/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/repository/ReviewRepository.java
@@ -1,6 +1,5 @@
 package com.backend.petplace.domain.review.repository;
 
-import com.backend.petplace.domain.mypage.dto.MyPageUserReviews;
 import com.backend.petplace.domain.place.entity.Place;
 import com.backend.petplace.domain.review.dto.ReviewInfo;
 import com.backend.petplace.domain.review.dto.response.MyReviewResponse;
@@ -18,28 +17,19 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
   List<Review> findByPlaceOrderByIdDesc(Place place);
 
   @Query("SELECT new com.backend.petplace.domain.review.dto.response.MyReviewResponse(" +
-      "r.id, p.id, p.name, p.address, r.rating, r.content, r.imageUrl, r.createdDate, pt.amount) " +
+      "r.id, r.place.id, r.place.name, r.place.address, " +
+      "r.rating, r.content, r.imageUrl, r.createdDate, pt.amount) " +
       "FROM Review r " +
-      "JOIN r.place p " + // Place 정보 JOIN
-      "LEFT JOIN Point pt ON pt.review = r " + // Point 정보 LEFT JOIN (포인트 없을 수도 있음)
-      "WHERE r.user = :user ORDER BY r.id DESC")
-  List<MyReviewResponse> findMyReviews(@Param("user") User user);
+      "JOIN r.place pl " +
+      "JOIN r.user u " +
+      "LEFT JOIN r.point pt " +
+      "WHERE r.user = :user")
+  List<MyReviewResponse> findMyReviewsWithProjection(@Param("user") User user);
 
   @Query("SELECT new com.backend.petplace.domain.review.dto.ReviewInfo(" +
-      "r.id, r.user.nickName, r.content, r.rating, r.imageUrl, r.createdDate) " +
+      "r.id, u.nickName, r.content, r.rating, r.imageUrl, r.createdDate) " +
       "FROM Review r " +
-      // User 정보는 Review 엔티티에 연관관계가 있으므로 JOIN FETCH 또는 DTO에서 직접 User ID 조회 방식 선택 가능
-      // 여기서는 간단하게 r.user.nickName 사용 (쿼리는 늘지만 N+1은 아님)
-      // 만약 User 정보가 더 많이 필요하면 JOIN FETCH r.user 추가 고려
-      "WHERE r.place = :place ORDER BY r.id DESC")
-  List<ReviewInfo> findReviewInfosByPlace(@Param("place") Place place);
-
-  @Query("SELECT new com.backend.petplace.domain.mypage.dto.MyPageUserReviews("+
-  "r.id, p.name, p.address, r.content, r.imageUrl, r.rating, r.createdDate) " +
-  "FROM Review r " +
-  "JOIN r.place p " +
-  "WHERE r.user = :user ORDER BY r.id DESC")
-  List<MyPageUserReviews> findByUserWithPlace(@Param("user") User user);
-
-  List<Review> findAllByPlace(Place place);
+      "JOIN r.user u " +
+      "WHERE r.place = :place")
+  List<ReviewInfo> findReviewInfosByPlaceWithProjection(@Param("place") Place place);
 }

--- a/backend/src/main/java/com/backend/petplace/domain/review/service/S3Service.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/service/S3Service.java
@@ -42,6 +42,13 @@ public class S3Service {
     return new PresignedUrlResponse(presignedUrl.toString(), uniqueFileName);
   }
 
+  public String getPublicUrl(String s3Path) {
+    if (s3Path == null || s3Path.isEmpty()) {
+      return null;
+    }
+    return amazonS3Client.getUrl(bucket, s3Path).toString();
+  }
+
   private String createUniqueFileName(String originalFilename, String dirName) {
     String extension = "";
     if (originalFilename != null && originalFilename.contains(".")) {


### PR DESCRIPTION
## 📌 관련 이슈
- close #137 

## 📝 변경 사항
### AS-IS
⚙️ 기존 코드 동작 방식:

- 리뷰 생성: 프론트엔드에서 S3 Presigned URL을 요청하고, 이미지를 S3에 PUT으로 업로드한 뒤, S3 경로(`reviews/uuid.jpg`)를 createReview API 요청 본문에 포함하여 백엔드로 전송했습니다. 백엔드는 이 경로를 DB Review 테이블의 imageUrl 컬럼에 저장했습니다.

- 리뷰 목록 조회 (`/api/v1/places/{placeId}/reviews, /api/v1/my/reviews`): 백엔드는 JPQL DTO 프로젝션을 사용하여 Review와 연관된 데이터를 조회하고 ReviewInfo 또는 MyReviewResponse DTO를 생성했습니다. 이 과정에서 **DB에 저장된 S3 경로가 imageUrl 필드에 담겨** 프론트엔드로 전달되었습니다.

- 프론트엔드 렌더링: PlaceSidebar.tsx와 MyPage.tsx는 백엔드로부터 받은 imageUrl(**S3 경로**)을 <img> 태그의 src 속성에 그대로 사용했습니다.

❎ 기존 문제점:

- 이미지 미표시: <img> 태그의 src에 **S3 경로**(`reviews/uuid.jpg`)가 들어가면서, 브라우저는 이를 현재 도메인(`http://localhost:3000`) 기준으로 해석 (`http://localhost:3000/reviews/uuid.jpg`)하여 이미지를 찾지 못했습니다. 이미지가 보이려면 **전체 S3 URL** (`https://.../reviews/uuid.jpg`)이 필요했습니다.

### TO-BE
✅ 변경된 내용:

- 백엔드 S3 URL 변환 로직 적용:

   - Review 엔티티에 Point와의 OneToOne 매핑을 추가하여 JPQL에서 r.point 접근 오류를 해결했습니다.

   - ReviewRepository의 findReviewInfosByPlaceWithProjection, findMyReviewsWithProjection 메서드 (JPQL DTO 프로젝션)는 S3 경로가 포함된 DTO를 반환하도록 유지했습니다 (N+1 문제 해결).

    - ReviewService (getReviewByPlace, getMyReviews)에서 리포지토리로부터 DTO 리스트를 받은 후, S3Service.getPublicUrl()을 호출하여 ⭐️**각 DTO의 imageUrl(S3 경로)을 전체 공개 URL로 변환하는 후처리 로직을 추가했습니다.** ⭐️

   - ReviewInfo와 MyReviewResponse DTO에 Setter 대신, 전체 URL로 **imageUrl을 교체한 새 DTO 인스턴스를 반환하는 정적 팩토리 메서드**(withFullImageUrl, withDetails)를 추가하여 불변성을 유지했습니다.

   - PlaceInfo DTO의 생성자 접근 제어자를 private에서 package-private으로 변경하여 PointTransaction DTO 프로젝션 오류를 해결했습니다.

- 프론트엔드 타입 및 API 연동 수정:

   - search/placeService.ts의 ReviewDetail 타입을 백엔드 ReviewInfo DTO와 일치시켰습니다.

   - MyPage.tsx 내 Review 인터페이스를 삭제하고, 백엔드 MyReviewResponse DTO와 일치하는 인터페이스를 정의했습니다.

   - MyPage.tsx에서` /my-page` API 대신 `/api/v1/my/reviews` API를 호출하는 fetchMyReviews 함수를 사용하도록 수정하고, reviews 상태 타입을 MyReviewResponse[]로 변경했습니다.

- 프론트엔드 렌더링 수정:

   - PlaceSidebar.tsx와 MyPage.tsx의 리뷰 목록 렌더링(.map) 시 key prop을 review.reviewId로 수정했습니다.

   - MyPage.tsx 리뷰 목록에서 장소 이름을 review.place.placeName으로, 날짜를 review.createdDate로 수정했습니다.

   - 두 컴포넌트 모두 <img> 태그의 src는 review.imageUrl을 사용합니다. (**백엔드에서 전체 URL을 제공**)

✅ 문제가 해결된 방식:

- 백엔드가 S3 경로가 아닌 **전체 공개 URL**을 imageUrl 필드에 담아 프론트엔드로 전달함으로써, <img> 태그가 올바른 이미지 주소를 참조하게 되어 이미지가 정상적으로 표시됩니다.

- 프론트엔드(MyPage.tsx)가 최신 API 엔드포인트(/api/v1/my/reviews)와 백엔드 DTO(MyReviewResponse) 구조에 맞게 데이터를 요청하고 상태를 관리하며 렌더링하도록 수정하여, 장소 이름 누락 및 key prop 경고 문제가 해결되었습니다.

- 백엔드는 DTO 프로젝션과 서비스 레이어 후처리를 조합하여 N+1 문제 없이 데이터를 조회하고 S3 URL 변환 책임을 S3Service가 갖도록 유지했습니다.

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 작성한 리뷰 내용 반영
<img width="856" height="1248" alt="image" src="https://github.com/user-attachments/assets/dd1e9fbc-93ea-4007-9da8-95b8b3f003cf" />

- 사진 리뷰 등록
<img width="836" height="798" alt="image" src="https://github.com/user-attachments/assets/07ccffdd-4f96-4737-a488-3423868a7207" />

- 사진 리뷰 포인트 정상 적립
<img width="1030" height="564" alt="image" src="https://github.com/user-attachments/assets/58be33c7-b583-478b-ae42-d9881fded63b" />

- 마이페이지 리뷰 목록 조회
<img width="1116" height="1204" alt="image" src="https://github.com/user-attachments/assets/e7540981-5845-4b58-8305-5332b2efe65c" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
미리 말씀 드리긴 했지만, 불가피하게 창중님 코드를 수정하게 돼서 죄송합니다 🥲 그래도 리뷰 부분만 건드려서 큰 수정은 없습니다 !
전체 URL로 변환하는 것은 어렵지 않았으나, 응답 dto도 많고 연결된 부분이 많아서 시간이 좀 걸렸습니다 .. 
프론트는 다행히 창중님께서 잘 작성해주신 덕분에 금방 했던 것 같습니다. 감사합니다 :)
다들 지금까지 기다려주셔서 감사합니다 😭
