### PR TITLE
Refactor/Test: Place 엔티티에 낙관적 락 적용 및 동시성 테스트 추가

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/place/entity/Place.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/entity/Place.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,6 +36,9 @@ public class Place extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
+
+  @Version
+  private Long version;
 
   @Column(nullable = false, length = 100, unique = true)
   private String uniqueKey;

--- a/backend/src/main/java/com/backend/petplace/domain/place/entity/Place.java
+++ b/backend/src/main/java/com/backend/petplace/domain/place/entity/Place.java
@@ -38,7 +38,7 @@ public class Place extends BaseEntity {
   private Long id;
 
   @Version
-  private Long version;
+  private Long version = 0L;
 
   @Column(nullable = false, length = 100, unique = true)
   private String uniqueKey;

--- a/backend/src/main/java/com/backend/petplace/domain/review/dto/request/ReviewCreateRequest.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/dto/request/ReviewCreateRequest.java
@@ -3,10 +3,12 @@ package com.backend.petplace.domain.review.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.Range;
 
+@AllArgsConstructor
 @Getter
 @Schema(description = "리뷰 등록 요청 DTO")
 public class ReviewCreateRequest {

--- a/backend/src/test/java/com/backend/petplace/domain/review/service/ReveiwServiceTest.java
+++ b/backend/src/test/java/com/backend/petplace/domain/review/service/ReveiwServiceTest.java
@@ -1,0 +1,254 @@
+package com.backend.petplace.domain.review.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.backend.petplace.domain.place.entity.Category1Type;
+import com.backend.petplace.domain.place.entity.Category2Type;
+import com.backend.petplace.domain.place.entity.Place;
+import com.backend.petplace.domain.place.repository.PlaceRepository;
+import com.backend.petplace.domain.point.repository.PointRepository;
+import com.backend.petplace.domain.review.dto.request.ReviewCreateRequest;
+import com.backend.petplace.domain.review.repository.ReviewRepository;
+import com.backend.petplace.domain.user.entity.User;
+import com.backend.petplace.domain.user.repository.UserRepository;
+import jakarta.persistence.OptimisticLockException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+@SpringBootTest
+public class ReveiwServiceTest {
+
+  @Autowired
+  private ReviewService reviewService;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private PlaceRepository placeRepository;
+
+  @Autowired
+  private ReviewRepository reviewRepository;
+
+  @Autowired
+  private PointRepository pointRepository;
+
+  private User savedUserA;
+
+  private User savedUserB;
+
+  private Place savedPlace;
+
+  @BeforeEach
+  void setup() {
+    User userA = User.builder()
+        .nickName("TestUserA")
+        .email("TestUserA@test.com")
+        .password("password")
+        .address("Test Address A")
+        .zipcode("12345")
+        .build();
+    savedUserA = userRepository.save(userA);
+
+    User userB = User.builder()
+        .nickName("TestUserB")
+        .email("TestUserB@test.com")
+        .password("password")
+        .address("Test Address B")
+        .zipcode("12345")
+        .build();
+    savedUserB = userRepository.save(userB);
+
+    Place place = Place.builder()
+        .name("Test Place")
+        .uniqueKey("test-key-12345")
+        .category1(Category1Type.PET_CAFE_RESTAURANT)
+        .category2(Category2Type.CAFE)
+        .latitude(37.123)
+        .longitude(127.123)
+        .build();
+    savedPlace = placeRepository.save(place);
+  }
+
+  @AfterEach
+  void tearDown() {
+    pointRepository.deleteAllInBatch();
+    reviewRepository.deleteAllInBatch();
+    placeRepository.deleteAllInBatch();
+    userRepository.deleteAllInBatch();
+  }
+
+  @Test
+  @DisplayName("서로 다른 유저가 같은 장소에 리뷰 동시 등록할 시 갱신 분실 방지 테스트")
+  void placeOptimisticLockTest() throws InterruptedException {
+
+    // given
+    int threadCount = 2;
+    ExecutorService executorService = Executors.newFixedThreadPool(threadCount); // 스레드 풀 생성
+    CountDownLatch latch = new CountDownLatch(1); // 모든 스레드가 준비될 때까지 대기 (신호 기다림)
+
+    // 동시성 환경에서 안전하게 성공/실패 횟수 세기 위한 변수
+    AtomicInteger successCount = new AtomicInteger(0);
+    AtomicInteger failureCount = new AtomicInteger(0);
+
+    // 요청 1 (별점 5점)
+    ReviewCreateRequest requestA = new ReviewCreateRequest(
+        savedPlace.getId(),
+        "첫 번째 리뷰(User A) : 아주 좋습니다! 별점 5점",
+        5,
+        null);
+    // 요청 2 (별점 1점)
+    ReviewCreateRequest requestB = new ReviewCreateRequest(
+        savedPlace.getId(),
+        "두 번째 리뷰(User B) : 별로예요!!!! 별점 1점",
+        1,
+        null);
+
+    // when
+    Runnable taskA = () -> {
+      try {
+        latch.await(); // 모든 스레드가 준비될 때까지 대기 (신호 기다림)
+        reviewService.createReview(savedUserA.getId(), requestA); // 리뷰 등록 시도
+        successCount.incrementAndGet(); // 성공 횟수 증가
+      }
+      // 충돌 예외
+      catch (ObjectOptimisticLockingFailureException | OptimisticLockException e) {
+        failureCount.incrementAndGet(); // 실패 횟수 증가
+      }
+      // 그 외 예외
+      catch (Exception e) {
+        e.printStackTrace();
+      }
+  };
+
+    Runnable taskB = () -> {
+      try {
+        latch.await();
+        reviewService.createReview(savedUserB.getId(), requestB);
+        successCount.incrementAndGet();
+      } catch (ObjectOptimisticLockingFailureException | OptimisticLockException e) {
+        failureCount.incrementAndGet();
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    };
+
+    // 모든 스레드 준비 완료, 동시에 시작
+    executorService.submit(taskA);
+    executorService.submit(taskB);
+
+    // 신호 보내기
+    latch.countDown();
+
+    // 스레드 풀 종료 대기
+    Thread.sleep(1000);
+
+    // then
+    Place resultPlace = placeRepository.findById(savedPlace.getId()).get(); // DB에서 최신 상태 조회 (최종 결과)
+
+    // 결과 검증 (성공 1회, 실패 1회여야 함)
+    assertThat(successCount.get()).isEqualTo(1);
+    assertThat(failureCount.get()).isEqualTo(1);
+
+    // DB 데이터 검증 (리뷰 1개, 평균 별점은 성공한 리뷰의 별점이어야 함)
+    assertThat(reviewRepository.count()).isEqualTo(1);
+    assertThat(resultPlace.getAverageRating()).isIn(1.0, 5.0); // 성공한 리뷰 별점
+    assertThat(resultPlace.getTotalReviewCount()).isEqualTo(1);
+    assertThat(resultPlace.getVersion()).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("한 사용자 같은 장소에 리뷰 2개 동시 등록할 시 DB UNIQUE 제약 테스트")
+  void placeDbUniqueTest() throws InterruptedException {
+
+    // given
+    int threadCount = 2;
+    ExecutorService executorService = Executors.newFixedThreadPool(threadCount); // 스레드 풀 생성
+    CountDownLatch latch = new CountDownLatch(1); // 모든 스레드가 준비될 때까지 대기 (신호 기다림)
+
+    // 동시성 환경에서 안전하게 성공/실패 횟수 세기 위한 변수
+    AtomicInteger successCount = new AtomicInteger(0);
+    AtomicInteger failureCount = new AtomicInteger(0);
+
+    // 요청 1 (별점 5점)
+    ReviewCreateRequest requestA = new ReviewCreateRequest(
+        savedPlace.getId(),
+        "첫 번째 리뷰 : 아주 좋습니다! 별점 5점",
+        5,
+        null);
+    // 요청 2 (별점 1점)
+    ReviewCreateRequest requestB = new ReviewCreateRequest(
+        savedPlace.getId(),
+        "두 번째 리뷰 : 별로예요!!!! 별점 1점",
+        1,
+        null);
+
+    // when
+    Runnable taskA = () -> {
+      try {
+        latch.await(); // 모든 스레드가 준비될 때까지 대기 (신호 기다림)
+        reviewService.createReview(savedUserA.getId(), requestA); // 리뷰 등록 시도
+        successCount.incrementAndGet(); // 성공 횟수 증가
+      }
+      // 충돌 예외
+      catch (ObjectOptimisticLockingFailureException | OptimisticLockException e) {
+        failureCount.incrementAndGet(); // 실패 횟수 증가
+      }
+      // DB UNIQUE 제약조건 위반 예외
+      catch (DataIntegrityViolationException e) {
+        failureCount.incrementAndGet(); // 실패 횟수 증가
+      }
+      // 그 외 예외
+      catch (Exception e) {
+        e.printStackTrace();
+      }
+    };
+
+    Runnable taskB = () -> {
+      try {
+        latch.await();
+        reviewService.createReview(savedUserA.getId(), requestB);
+        successCount.incrementAndGet();
+      } catch (ObjectOptimisticLockingFailureException | OptimisticLockException e) {
+        failureCount.incrementAndGet();
+      } catch (DataIntegrityViolationException e) {
+        failureCount.incrementAndGet();
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    };
+
+    // 모든 스레드 준비 완료, 동시에 시작
+    executorService.submit(taskA);
+    executorService.submit(taskB);
+
+    // 신호 보내기
+    latch.countDown();
+
+    // 스레드 풀 종료 대기
+    Thread.sleep(1000);
+
+    // then
+    Place resultPlace = placeRepository.findById(savedPlace.getId()).get(); // DB에서 최신 상태 조회 (최종 결과)
+
+    // 결과 검증 (성공 1회, 실패 1회여야 함)
+    assertThat(successCount.get()).isEqualTo(1);
+    assertThat(failureCount.get()).isEqualTo(1);
+
+    // DB 데이터 검증 (리뷰 1개, 평균 별점은 성공한 리뷰의 별점이어야 함)
+    assertThat(reviewRepository.count()).isEqualTo(1);
+    assertThat(resultPlace.getAverageRating()).isIn(1.0, 5.0); // 성공한 리뷰 별점
+    assertThat(resultPlace.getTotalReviewCount()).isEqualTo(1);
+    assertThat(resultPlace.getVersion()).isEqualTo(1L);
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #148 

## 📝 변경 사항
### AS-IS
- `ReviewService.createReview` 메서드는 `Place` 엔티티의 `updateReviewStats`를 호출합니다.
- 하지만 별도의 동시성 제어 로직이 없어, 여러 리뷰 등록 요청이 동시에 발생할 경우 `Place`의 평균 평점 및 리뷰 수에서 **갱신 분실(Lost Update)** 문제가 발생할 수 있었습니다.
- 포인트 적립 로직은 DB의 `UNIQUE` 제약 조건으로 동시성이 제어되지만, `Place` 통계는 이에 해당하지 않았습니다.

### TO-BE
1.  `Place` 엔티티에 `@Version` 필드를 추가하여 **낙관적 락(Optimistic Lock)**을 적용했습니다.
2.  이제 `ReviewService`의 트랜잭션이 커밋될 때, JPA가 `Place`의 `version`을 자동으로 검사합니다.
3.  만약 동시 쓰기 충돌이 감지되면, JPA는 `OptimisticLockException`을 발생시켜 나중에 커밋하는 트랜잭션을 롤백시키고 사용자에게 오류를 반환합니다.
4.  `ReviewServiceTest`에 **멀티 스레드 동시성 테스트 코드(`placeOptimisticLockTest`)를 추가**했습니다.
    - (테스트 내용) 서로 다른 두 사용자가 동시에 같은 장소에 리뷰를 등록할 때, 한 건은 성공하고 한 건은 `OptimisticLockException` 으로 실패(롤백)함을 검증합니다.
    - (테스트 내용) 같은 사용자가 동시에 같은 장소에 리뷰를 등록할 때, `DataIntegrityViolationException` - UNIQUE 제약으로 실패(롤백)함을 검증합니다.
    - `Place`의 `totalReviewCount`와 `version`이 `1`만 증가함을 확인하여 데이터 정합성을 검증합니다.

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="1331" height="385" alt="image" src="https://github.com/user-attachments/assets/6d03c799-35cf-49a9-b3f0-7b71c705e2e2" />
<img width="537" height="507" alt="image" src="https://github.com/user-attachments/assets/ccff57ec-c8e6-4093-8767-7e3d6133babe" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
동시성 제어 문제와 오버 엔지니어링을 많이 고민하다 장소의 리뷰 통계 내역만 동시성 제어하기로 결정했습니다.
이유는 아래와 같습니다.

> 1. 리뷰 등록은 같은 사용자가 더블 클릭을 할 시에만 등록됨 ➡️ 확률 적음 또한, 정합성 중요도 낮음 ➡️ 기획 상 리뷰 여러개 등록해도 됨 (실수로 같은 리뷰 2개 올라가도 문제가 크지 않음) ➡️ 성능을 위해 락 도입 불필요
> 2. 포인트 적립은 결제와 직결되므로 정합성 중요함 ➡️ 하지만, DB에서 제약 조건으로 이미 동시성 제어 중 ➡️ 성능을 위해 추가 락 도입 불필요
> 3. 장소 리뷰 통계는 정합성은 보통이지만, 사용자에게 정보를 제공한다는 중요 역할이 있음 ➡️ 갱신 분실 문제 빈도수가 다른 기능 문제의 빈도수보다 많을 것이라 판단

재시도 로직 또한 구현하지 않아 리뷰 등록이 되지 않은 사용자는 다시 한 번 리뷰 등록 시도해야 합니다.
이렇게 구현한 이유는 아래와 같습니다.

> - 평균 별점과 리뷰 수는 ‘강한 정합성’이 필요하지 않은 영역 ➡️ 낙관적 락 충돌 시 무한 재시도는 오버엔지니어링이라 판단
> - 충돌 확률도 낮은 편으로 예상 ➡️ ‘재시도 없음’ 또는 ‘1회 재시도’ 정도면 충분하다고 판단 
> - 즉, 불필요하게 복잡도를 높이지 않고, 성능을 오히려 해치지 않도록 판단하여 구현