### PR TITLE
[Feature] 내 북마크 목록 조회 API 구현 (DB 기반)

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/bookmark/controller/BookmarkController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/bookmark/controller/BookmarkController.java
@@ -1,14 +1,17 @@
 package com.backend.petplace.domain.bookmark.controller;
 
+import com.backend.petplace.domain.bookmark.dto.response.MyBookmarkPlaceResponse;
 import com.backend.petplace.domain.bookmark.service.BookmarkService;
 import com.backend.petplace.global.jwt.CustomUserDetails;
 import com.backend.petplace.global.response.ApiResponse;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Positive.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,6 +43,15 @@ public class BookmarkController implements BookmarkSpecification{
   ) {
     bookmarkService.removeBookmark(userDetails.getUserId(), placeId);
     return ResponseEntity.ok(ApiResponse.success());
+  }
+
+  @GetMapping("/me")
+  public ResponseEntity<ApiResponse<List<MyBookmarkPlaceResponse>>> getMyBookmarks(
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    List<MyBookmarkPlaceResponse> results = bookmarkService.getMyBookmarks(userDetails.getUserId());
+
+    return ResponseEntity.ok(ApiResponse.success(results));
   }
 
 }

--- a/backend/src/main/java/com/backend/petplace/domain/bookmark/controller/BookmarkController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/bookmark/controller/BookmarkController.java
@@ -5,7 +5,7 @@ import com.backend.petplace.domain.bookmark.service.BookmarkService;
 import com.backend.petplace.global.jwt.CustomUserDetails;
 import com.backend.petplace.global.response.ApiResponse;
 import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.Positive.List;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -55,5 +55,4 @@ public class BookmarkController implements BookmarkSpecification{
 
     return ResponseEntity.ok(ApiResponse.success(results));
   }
-
 }

--- a/backend/src/main/java/com/backend/petplace/domain/bookmark/controller/BookmarkController.java
+++ b/backend/src/main/java/com/backend/petplace/domain/bookmark/controller/BookmarkController.java
@@ -45,11 +45,13 @@ public class BookmarkController implements BookmarkSpecification{
     return ResponseEntity.ok(ApiResponse.success());
   }
 
+  @Override
   @GetMapping("/me")
   public ResponseEntity<ApiResponse<List<MyBookmarkPlaceResponse>>> getMyBookmarks(
       @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
-    List<MyBookmarkPlaceResponse> results = bookmarkService.getMyBookmarks(userDetails.getUserId());
+    List<MyBookmarkPlaceResponse> results =
+        bookmarkService.getMyBookmarks(userDetails.getUserId());
 
     return ResponseEntity.ok(ApiResponse.success(results));
   }

--- a/backend/src/main/java/com/backend/petplace/domain/bookmark/controller/BookmarkSpecification.java
+++ b/backend/src/main/java/com/backend/petplace/domain/bookmark/controller/BookmarkSpecification.java
@@ -5,6 +5,7 @@ import static com.backend.petplace.global.response.ErrorCode.NOT_FOUND_BOOKMARK;
 import static com.backend.petplace.global.response.ErrorCode.NOT_FOUND_MEMBER;
 import static com.backend.petplace.global.response.ErrorCode.NOT_FOUND_PLACE;
 
+import com.backend.petplace.domain.bookmark.dto.response.MyBookmarkPlaceResponse;
 import com.backend.petplace.global.config.swagger.ApiErrorCodeExamples;
 import com.backend.petplace.global.jwt.CustomUserDetails;
 import com.backend.petplace.global.response.ApiResponse;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Positive;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "Bookmark", description = "북마크 API")
@@ -60,6 +62,19 @@ public interface BookmarkSpecification {
           example = "1"
       )
       @Positive Long placeId
+  );
+
+  @ApiErrorCodeExamples({NOT_FOUND_MEMBER})
+  @Operation(
+      summary = "내 북마크 목록 조회",
+      description = """
+          로그인한 사용자가 북마크한 장소 목록을 조회합니다.
+          - 응답에는 장소 ID, 이름, 카테고리, 주소, 좌표, 주차/반려동물 허용 여부, 평점 정보 등이 포함됩니다.
+          """
+  )
+  ResponseEntity<ApiResponse<List<MyBookmarkPlaceResponse>>> getMyBookmarks(
+      @Parameter(hidden = true)
+      CustomUserDetails userDetails
   );
 }
 

--- a/backend/src/main/java/com/backend/petplace/domain/bookmark/dto/response/BookmarkResponse.java
+++ b/backend/src/main/java/com/backend/petplace/domain/bookmark/dto/response/BookmarkResponse.java
@@ -1,5 +1,0 @@
-package com.backend.petplace.domain.bookmark.dto.response;
-
-public class BookmarkResponse {
-
-}

--- a/backend/src/main/java/com/backend/petplace/domain/bookmark/dto/response/MyBookmarkPlaceResponse.java
+++ b/backend/src/main/java/com/backend/petplace/domain/bookmark/dto/response/MyBookmarkPlaceResponse.java
@@ -1,0 +1,18 @@
+package com.backend.petplace.domain.bookmark.dto.response;
+
+import com.backend.petplace.domain.place.entity.Category1Type;
+import com.backend.petplace.domain.place.entity.Category2Type;
+
+public record MyBookmarkPlaceResponse(
+    Long placeId,
+    String name,
+    Category1Type category1,
+    Category2Type category2,
+    String address,
+    Double latitude,
+    Double longitude,
+    Boolean parking,
+    Boolean petAllowed,
+    Double averageRating,
+    Integer totalReviewCount
+) {}

--- a/backend/src/main/java/com/backend/petplace/domain/bookmark/dto/response/MyBookmarkPlaceResponse.java
+++ b/backend/src/main/java/com/backend/petplace/domain/bookmark/dto/response/MyBookmarkPlaceResponse.java
@@ -2,6 +2,7 @@ package com.backend.petplace.domain.bookmark.dto.response;
 
 import com.backend.petplace.domain.place.entity.Category1Type;
 import com.backend.petplace.domain.place.entity.Category2Type;
+import com.backend.petplace.domain.place.entity.Place;
 
 public record MyBookmarkPlaceResponse(
     Long placeId,
@@ -15,4 +16,20 @@ public record MyBookmarkPlaceResponse(
     Boolean petAllowed,
     Double averageRating,
     Integer totalReviewCount
-) {}
+) {
+  public static MyBookmarkPlaceResponse from(Place place) {
+    return new MyBookmarkPlaceResponse(
+        place.getId(),
+        place.getName(),
+        place.getCategory1(),
+        place.getCategory2(),
+        place.getAddress(),
+        place.getLatitude(),
+        place.getLongitude(),
+        place.getParking(),
+        place.getPetAllowed(),
+        place.getAverageRating(),
+        place.getTotalReviewCount()
+    );
+  }
+}

--- a/backend/src/main/java/com/backend/petplace/domain/bookmark/repository/BookmarkRepository.java
+++ b/backend/src/main/java/com/backend/petplace/domain/bookmark/repository/BookmarkRepository.java
@@ -1,12 +1,23 @@
 package com.backend.petplace.domain.bookmark.repository;
 
 import com.backend.petplace.domain.bookmark.entity.Bookmark;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
   boolean existsByUserIdAndPlace_Id(Long userId, Long placeId);
 
   Optional<Bookmark> findByUserIdAndPlace_Id(Long userId, Long placeId);
+
+  @Query("""
+      select b 
+      from Bookmark b 
+      join fetch b.place 
+      where b.userId = :userId
+      """)
+  List<Bookmark> findAllByUserIdWithPlace(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/backend/petplace/domain/bookmark/service/BookmarkService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/bookmark/service/BookmarkService.java
@@ -5,6 +5,7 @@ import static com.backend.petplace.global.response.ErrorCode.NOT_FOUND_BOOKMARK;
 import static com.backend.petplace.global.response.ErrorCode.NOT_FOUND_MEMBER;
 import static com.backend.petplace.global.response.ErrorCode.NOT_FOUND_PLACE;
 
+import com.backend.petplace.domain.bookmark.dto.response.MyBookmarkPlaceResponse;
 import com.backend.petplace.domain.bookmark.entity.Bookmark;
 import com.backend.petplace.domain.bookmark.repository.BookmarkRepository;
 import com.backend.petplace.domain.place.entity.Place;
@@ -12,6 +13,7 @@ import com.backend.petplace.domain.place.repository.PlaceRepository;
 import com.backend.petplace.domain.user.entity.User;
 import com.backend.petplace.domain.user.repository.UserRepository;
 import com.backend.petplace.global.exception.BusinessException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,6 +46,17 @@ public class BookmarkService {
     findPlaceById(placeId);
 
     bookmarkRepository.delete(findBookmark(userId, placeId));
+  }
+
+  @Transactional(readOnly = true)
+  public List<MyBookmarkPlaceResponse> getMyBookmarks(Long userId) {
+    findUserById(userId);
+
+    List<Bookmark> bookmarks = bookmarkRepository.findAllByUserIdWithPlace(userId);
+
+    return bookmarks.stream()
+        .map(bookmark -> MyBookmarkPlaceResponse.from(bookmark.getPlace()))
+        .toList();
   }
 
   private User findUserById(Long userId) {


### PR DESCRIPTION
## 📌 관련 이슈
- close #152 

## 📝 변경 사항
### AS-IS
* 북마크 추가/삭제 기능만 존재
* 사용자가 북마크한 장소 목록을 조회하는 기능이 없음

### TO-BE
* `GET /api/v1/bookmark/me` API 구현
* 북마크 + 장소 정보를 `JOIN FETCH`로 조회하여 N+1 없이 처리
* `MyBookmarkPlaceResponse` DTO 추가 (필요한 정보만 제공)
* BookmarkSpecification에 Swagger 문서화 추가
* BookmarkController에 조회 로직 추가

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 사용자가 본인의 북마크 목록 조회
<img width="1532" height="1446" alt="image" src="https://github.com/user-attachments/assets/d906c8a6-5079-4b9f-ad52-5c15b82a2987" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
* Redis 캐싱을 다음 PR에서 추가할 예정이라 구조 확장성을 고려했습니다.


