### PR TITLE
[Feature] Redis 기반 북마크 조회 캐싱 기능 구현

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/bookmark/service/BookmarkService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/bookmark/service/BookmarkService.java
@@ -13,7 +13,10 @@ import com.backend.petplace.domain.place.repository.PlaceRepository;
 import com.backend.petplace.domain.user.entity.User;
 import com.backend.petplace.domain.user.repository.UserRepository;
 import com.backend.petplace.global.exception.BusinessException;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
@@ -65,8 +68,43 @@ public class BookmarkService {
   public List<MyBookmarkPlaceResponse> getMyBookmarks(Long userId) {
     findUserById(userId);
 
+    String key = BOOKMARK_USER_KEY_PREFIX + userId;
+
+    // 1) Redis에서 이 유저의 북마크 placeId Set 조회
+    Set<String> cachedIds = stringRedisTemplate.opsForSet().members(key);
+
+    // 1-1) 캐시에 데이터가 있다면 → placeId들로 Place 조회
+    if (cachedIds != null && !cachedIds.isEmpty()) {
+
+      List<Long> placeIds = cachedIds.stream()
+          .map(Long::valueOf)
+          .toList();
+
+      List<Place> places = placeRepository.findAllById(placeIds);
+
+      // Optional: 순서를 정해주고 싶다면 여기서 정렬 (예: 이름 순, 생성일 순 등)
+      places.sort(Comparator.comparing(Place::getName));
+
+      return places.stream()
+          .map(MyBookmarkPlaceResponse::from)
+          .toList();
+    }
+
+    // 1-2) 캐시에 없으면 → DB에서 북마크 + place join으로 조회
     List<Bookmark> bookmarks = bookmarkRepository.findAllByUserIdWithPlace(userId);
 
+    if (bookmarks.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    // 2) Redis에 placeId들 적재
+    List<String> placeIdStrings = bookmarks.stream()
+        .map(b -> b.getPlace().getId().toString())
+        .toList();
+
+    stringRedisTemplate.opsForSet().add(key, placeIdStrings.toArray(String[]::new));
+
+    // 3) 응답 DTO 변환
     return bookmarks.stream()
         .map(bookmark -> MyBookmarkPlaceResponse.from(bookmark.getPlace()))
         .toList();

--- a/backend/src/main/java/com/backend/petplace/domain/bookmark/service/BookmarkService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/bookmark/service/BookmarkService.java
@@ -41,6 +41,11 @@ public class BookmarkService {
     }
 
     Bookmark saved = bookmarkRepository.save(Bookmark.createNewBookmark(user.getId(), place));
+
+    // Redis 캐시 갱신: 이 유저의 북마크 Set에 placeId 추가
+    String key = BOOKMARK_USER_KEY_PREFIX + userId;
+    stringRedisTemplate.opsForSet().add(key, placeId.toString());
+
     return saved.getId();
   }
 

--- a/backend/src/main/java/com/backend/petplace/domain/bookmark/service/BookmarkService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/bookmark/service/BookmarkService.java
@@ -15,6 +15,7 @@ import com.backend.petplace.domain.user.repository.UserRepository;
 import com.backend.petplace.global.exception.BusinessException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,9 +24,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class BookmarkService {
 
+  private static final String BOOKMARK_USER_KEY_PREFIX = "bookmark:user:";
+
   private final UserRepository userRepository;
   private final PlaceRepository placeRepository;
   private final BookmarkRepository bookmarkRepository;
+  private final StringRedisTemplate stringRedisTemplate;
 
   public Long addBookmark(Long userId, Long placeId) {
 

--- a/backend/src/main/java/com/backend/petplace/domain/bookmark/service/BookmarkService.java
+++ b/backend/src/main/java/com/backend/petplace/domain/bookmark/service/BookmarkService.java
@@ -55,6 +55,10 @@ public class BookmarkService {
     findPlaceById(placeId);
 
     bookmarkRepository.delete(findBookmark(userId, placeId));
+
+    // Redis 캐시 갱신: Set에서 placeId 제거
+    String key = BOOKMARK_USER_KEY_PREFIX + userId;
+    stringRedisTemplate.opsForSet().remove(key, placeId.toString());
   }
 
   @Transactional(readOnly = true)

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -54,6 +54,14 @@ cloud:
       auto: false
     stack:
       auto: false
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password:
+      timeout: 6000ms
+    cache:
+      type: redis
 
 import:
   enabled: false         # 로컬 최초 적재 시 true, 이후 false로 끄기


### PR DESCRIPTION
## 📌 관련 이슈
- close #155 

## 📝 변경 사항
### AS-IS
- 모든 북마크 기능(추가/삭제/조회)이 DB 접근 기반으로 동작
- 북마크 조회 시 Bookmark → Place fetch join 방식으로 매번 DB 접근 필요
- 반복 조회에서 성능 저하 가능성 존재

### TO-BE
- Redis Set(`bookmark:user:{userId}`) 활용한 북마크 목록 캐싱 구조 구현
- 북마크 추가/삭제 시 Redis 캐시 자동 동기화
  - 추가: `SADD bookmark:user:{userId} placeId`
  - 삭제: `SREM bookmark:user:{userId} placeId`
- 조회 시 Redis 우선 조회(Cache Hit) → 빠른 응답 가능
- 조회 시 Redis Miss → DB 조회 후 Redis에 placeId Set 캐싱
- 이후 “검색 결과에 isBookmarked 포함 기능”에서도 재사용 가능하도록 구조화

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 북마크 추가(캐싱 정상 저장)
<img width="606" height="80" alt="image" src="https://github.com/user-attachments/assets/8c314c70-5b6c-4e75-94d6-add377d2e8c8" />

- 북마크 삭제(캐싱 정보도 함께 삭제)
<img width="582" height="72" alt="image" src="https://github.com/user-attachments/assets/eb53358d-9ad6-4c6d-8399-96e932eb8b7e" />

- 처음 캐시에 아무것도 없을때(DB에서 조회 후 캐싱)
<img width="582" height="378" alt="image" src="https://github.com/user-attachments/assets/e602faf2-918b-40c7-b8b8-c00d8b06cbd4" />



## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
북마크 조회 성능 개선을 위해 Redis 기반 캐싱 구조를 도입했습니다.  
로직 자체는 Place 검색 기능에서 isBookmarked 표시에도 사용될 구조입니다.  
설계 방향과 캐싱 전략에 대해 검토 부탁드립니다.


