### PR TITLE
Test: 리뷰 도메인 (Review, ReviewInfo DTO) 단위 테스트

### DIFF
--- a/backend/src/main/java/com/backend/petplace/domain/review/dto/ReviewInfo.java
+++ b/backend/src/main/java/com/backend/petplace/domain/review/dto/ReviewInfo.java
@@ -3,11 +3,13 @@ package com.backend.petplace.domain.review.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@Builder
+@AllArgsConstructor
 @Schema(description = "장소 리뷰 목록에 포함될 개별 리뷰 정보")
 public class ReviewInfo {
 

--- a/backend/src/test/java/com/backend/petplace/domain/review/dto/ReviewInfoTest.java
+++ b/backend/src/test/java/com/backend/petplace/domain/review/dto/ReviewInfoTest.java
@@ -1,0 +1,48 @@
+package com.backend.petplace.domain.review.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ReviewInfoTest {
+
+  private ReviewInfo creatDummy() {
+    return ReviewInfo.builder()
+        .reviewId(1L)
+        .userName("TestUser")
+        .content("ReviewInfoDtoTest입니다.")
+        .rating(4)
+        .imageUrl("reviews/dummy-image-key.jpg") // S3 Path (기존 데이터)
+        .createdDate(LocalDate.now())
+        .build();
+  }
+
+  @Test
+  @DisplayName("withFullImageUrl: S3 경로를 CloudFront URL로 교체")
+  void withFullImageUrl() {
+
+    // given
+    ReviewInfo originalDto = creatDummy();
+    String expectedCloudFrontUrl = "https://d123.cloudfront.net";
+    String originalS3Path = originalDto.getImageUrl();
+    String expectedFullImageUrl = expectedCloudFrontUrl + "/" + originalS3Path;
+
+    // when
+    ReviewInfo resultDto = ReviewInfo.withFullImageUrl(originalDto, expectedFullImageUrl);
+
+    // then
+    assertThat(resultDto).isNotSameAs(originalDto); // 새로운 객체인지 확인
+
+    assertThat(resultDto.getReviewId()).isEqualTo(originalDto.getReviewId());
+    assertThat(resultDto.getUserName()).isEqualTo(originalDto.getUserName());
+    assertThat(resultDto.getContent()).isEqualTo(originalDto.getContent());
+    assertThat(resultDto.getRating()).isEqualTo(originalDto.getRating());
+
+    assertThat(resultDto.getImageUrl()).isEqualTo(expectedFullImageUrl); // URL이 교체되었는지 확인
+
+    assertThat(resultDto.getCreatedDate()).isEqualTo(LocalDate.now());
+  }
+
+}

--- a/backend/src/test/java/com/backend/petplace/domain/review/entity/ReviewTest.java
+++ b/backend/src/test/java/com/backend/petplace/domain/review/entity/ReviewTest.java
@@ -1,0 +1,45 @@
+package com.backend.petplace.domain.review.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.backend.petplace.domain.place.entity.Place;
+import com.backend.petplace.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ReviewTest {
+
+  @Test
+  @DisplayName("createNewReview: 필수 필드를 포함하여 새로운 Review 엔티티 생성")
+  void createNewReview() {
+    
+    // given
+    User mockUser = User.builder()
+        .nickName("TestUser")
+        .password("password")
+        .build();
+
+    Place mockPlace = Place.builder()
+        .id(1L)
+        .name("TestPlace")
+        .address("123 Test St")
+        .build();
+
+    int rating = 5;
+    String content = "This is a test review.";
+    String imageUrl = "reviews/test-image.jpg";
+
+  // when
+    Review newReview = Review.createNewReview(mockUser, mockPlace, content, rating, imageUrl);
+
+    // then
+    assertThat(newReview).isNotNull();
+    assertThat(newReview.getId()).isNull(); // 아직 저장되지 않았으므로 ID는 null이어야 함
+
+    assertThat(newReview.getUser()).isEqualTo(mockUser);
+    assertThat(newReview.getPlace()).isEqualTo(mockPlace);
+    assertThat(newReview.getContent()).isEqualTo(content);
+    assertThat(newReview.getRating()).isEqualTo(rating);
+    assertThat(newReview.getImageUrl()).isEqualTo(imageUrl);
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #158 

## 📝 변경 사항
### AS-IS
Review 엔티티 및 ReviewInfo DTO의 객체 생성 및 변환 로직에 대한 테스트 코드가 부재함.

### TO-BE
**1. Review 도메인 객체 단위 테스트 추가**
- `ReviewInfoTest.java`: 팩토리 메서드 `withFullImageUrl` 테스트 추가. (CloudFront URL 변환 및 불변성 검증)
- `ReviewTest.java`: 팩토리 메서드 `createNewReview` 테스트 추가. (필수 필드 매핑 검증)

**2. DTO Builder 패턴 도입 및 정리**
- `ReviewInfo` DTO에 `@Builder` 및 `@AllArgsConstructor`를 적용하고 `@NoArgsConstructor`를 제거하여 **객체 생성의 일관성**을 확보.
- 테스트 코드에서 `ReviewInfo.builder()`를 사용하여 가독성 높은 테스트 객체 생성 방식으로 전환.

**3. 안정성 확보**
- 향후 서비스 레이어 테스트 시, 하위 계층 객체의 안정성이 보장되어 테스트 실패 시 비즈니스 로직에만 집중할 수 있는 환경 마련.

## 🔍 테스트
- [x] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="600" height="251" alt="image" src="https://github.com/user-attachments/assets/a145ad8c-b203-42d0-a69d-aec2507361b6" />
<img width="616" height="323" alt="image" src="https://github.com/user-attachments/assets/9ee3fdad-093d-4910-a44a-a06ac3999a38" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
이제 좀 테스트코드 익숙해지는 것 같긴한데... 서비스 레이어는 어떨지 모르겠네요..
피드백 환영입니다 !


