### PR TITLE
Test: 포인트 도메인 (Point 엔티티, 관련 DTO) 단위 테스트

### DIFF
--- a/backend/src/test/java/com/backend/petplace/domain/point/dto/PlaceInfoTest.java
+++ b/backend/src/test/java/com/backend/petplace/domain/point/dto/PlaceInfoTest.java
@@ -43,6 +43,4 @@ public class PlaceInfoTest {
     assert info.getPlaceName().equals(PLACE_NAME);
     assert info.getFullAddress().equals(ADDRESS);
   }
-
-
 }

--- a/backend/src/test/java/com/backend/petplace/domain/point/dto/PlaceInfoTest.java
+++ b/backend/src/test/java/com/backend/petplace/domain/point/dto/PlaceInfoTest.java
@@ -1,0 +1,48 @@
+package com.backend.petplace.domain.point.dto;
+
+import com.backend.petplace.domain.place.entity.Place;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class PlaceInfoTest {
+
+  private final Long PLACE_ID = 1L;
+  private final String PLACE_NAME = "멍멍카페";
+  private final String ADDRESS = "서울 강남구 테헤란로 123";
+
+  @Test
+  @DisplayName("fronProjection: Repository 결과 받아 정확히 DTO 생성")
+  void testFrontProjection() {
+
+    // when
+    // 정적 팩토리 메서드 검증이므로 직접 호출 (builder 패턴 X)
+    PlaceInfo info = PlaceInfo.fromProjection(PLACE_ID, PLACE_NAME, ADDRESS);
+
+    //then
+    assert info.getPlaceId().equals(PLACE_ID);
+    assert info.getPlaceName().equals(PLACE_NAME);
+    assert info.getFullAddress().equals(ADDRESS);
+  }
+
+  @Test
+  @DisplayName("from: Place 엔티티 받아 정확히 DTO 생성")
+  void testFromEntity() {
+
+    // given
+    Place mockPlace = Place.builder()
+        .id(PLACE_ID)
+        .name(PLACE_NAME)
+        .address(ADDRESS)
+        .build();
+
+    // when
+    PlaceInfo info = PlaceInfo.from(mockPlace);
+
+    //then
+    assert info.getPlaceId().equals(PLACE_ID);
+    assert info.getPlaceName().equals(PLACE_NAME);
+    assert info.getFullAddress().equals(ADDRESS);
+  }
+
+
+}

--- a/backend/src/test/java/com/backend/petplace/domain/point/dto/PointHistoryResponseTest.java
+++ b/backend/src/test/java/com/backend/petplace/domain/point/dto/PointHistoryResponseTest.java
@@ -1,0 +1,39 @@
+package com.backend.petplace.domain.point.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.backend.petplace.domain.point.dto.response.PointHistoryResponse;
+import com.backend.petplace.domain.point.entity.PointDescription;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class PointHistoryResponseTest {
+
+  @Test
+  @DisplayName("총 포인트와 내역 목록을 정확히 초기화하는 생성자 테스트")
+  void testConstructor() {
+    // given
+    int totalPoints = 2500;
+
+    PointTransaction mockTransaction = new PointTransaction(
+        1L,
+        10L,
+        "멍멍카페",
+        "서울 강남구 테헤란로 123",
+        PointDescription.REVIEW_TEXT,
+        LocalDate.now(),
+        100
+    );
+    List<PointTransaction> history = List.of(mockTransaction);
+
+    // when
+    PointHistoryResponse response = new PointHistoryResponse(totalPoints, history);
+
+    // then
+    assertThat(response.getTotalPoints()).isEqualTo(totalPoints);
+    assertThat(response.getHistory()).hasSize(1);
+    assertThat(response.getHistory().get(0).getPointId()).isEqualTo(1L);
+  }
+}

--- a/backend/src/test/java/com/backend/petplace/domain/point/dto/PointTransactionTest.java
+++ b/backend/src/test/java/com/backend/petplace/domain/point/dto/PointTransactionTest.java
@@ -1,0 +1,74 @@
+package com.backend.petplace.domain.point.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.backend.petplace.domain.point.entity.PointDescription;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class PointTransactionTest {
+
+  private final Long POINT_ID = 1L;
+  private final Long PLACE_ID = 2L;
+  private final String PLACE_NAME = "멍멍카페";
+  private final String ADDRESS = "서울 강남구 테헤란로 123";
+  private final LocalDate REWARD_DATE = LocalDate.of(2025, 11, 19);
+  private final Integer POINT_AMOUNT = 100;
+
+  @Test
+  @DisplayName("사진 리뷰 등록 시 hasImage = true")
+  void testHasImageTrueForPhotoReview() {
+
+    // given
+    PointDescription photoDesc = PointDescription.REVIEW_PHOTO;
+
+    // when
+    PointTransaction transaction = new PointTransaction(
+        POINT_ID,
+        PLACE_ID,
+        PLACE_NAME,
+        ADDRESS,
+        photoDesc,
+        REWARD_DATE,
+        POINT_AMOUNT
+    );
+
+    // then
+    // hasImage 필드 검증
+    assertThat(transaction.isHasImage()).isTrue();
+
+    // description 필드 검증
+    assertThat(transaction.getDescription()).isEqualTo("사진 리뷰 작성");
+
+    assertThat(transaction.getPlace().getPlaceId()).isEqualTo(PLACE_ID);
+  }
+
+  @Test
+  @DisplayName("텍스트 리뷰 등록 시 hasImage = false")
+  void testHasImageFalseForTextReview() {
+    // given
+    PointDescription textDesc = PointDescription.REVIEW_TEXT;
+
+    // when
+    PointTransaction transaction = new PointTransaction(
+        POINT_ID,
+        PLACE_ID,
+        PLACE_NAME,
+        ADDRESS,
+        textDesc,
+        REWARD_DATE,
+        POINT_AMOUNT
+    );
+
+    // then
+    // hasImage 필드 검증
+    assertThat(transaction.isHasImage()).isFalse();
+
+    // description 필드 검증
+    assertThat(transaction.getDescription()).isEqualTo("텍스트 리뷰 작성");
+
+    assertThat(transaction.getPoints()).isEqualTo(POINT_AMOUNT);
+    assertThat(transaction.getCreatedDate()).isEqualTo(REWARD_DATE);
+  }
+}

--- a/backend/src/test/java/com/backend/petplace/domain/point/entity/PointTest.java
+++ b/backend/src/test/java/com/backend/petplace/domain/point/entity/PointTest.java
@@ -1,0 +1,105 @@
+package com.backend.petplace.domain.point.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.backend.petplace.domain.place.entity.Place;
+import com.backend.petplace.domain.point.type.PointPolicy;
+import com.backend.petplace.domain.review.entity.Review;
+import com.backend.petplace.domain.user.entity.User;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class PointTest {
+
+  private User createMockUser() {
+    return User.builder()
+        .id(1L)
+        .email("test@example.com")
+        .build();
+  }
+
+  private Place createMockPlace() {
+    return Place.builder()
+        .id(1L)
+        .name("Test Place")
+        .address("123 Test St")
+        .build();
+  }
+
+  @Test
+  @DisplayName("createFronReview: 사진 리뷰 등록 시 사진 리뷰 포인트 생성")
+  void createFromReview_PhotoReview() {
+
+    // given
+    Review reviewWithImage = Review.builder()
+        .user(createMockUser())
+        .place(createMockPlace())
+        .content("Great place!")
+        .rating(5)
+        .imageUrl("reviews/test-image.jpg")
+        .build();
+
+    // when
+    Point point = Point.createFromReview(reviewWithImage);
+
+    // then
+    // 사진 리뷰 적립 확인
+    assertThat(point.getAmount()).isEqualTo(PointPolicy.REVIEW_PHOTO_POINTS.getValue());
+
+    // 적립 포인트 설명 확인
+    assertThat(point.getDescription()).isEqualTo(PointDescription.REVIEW_PHOTO);
+
+    // 필드 매핑 확인
+    assertThat(point.getUser()).isEqualTo(reviewWithImage.getUser());
+    assertThat(point.getPlace()).isEqualTo(reviewWithImage.getPlace());
+    assertThat(point.getRewardDate()).isEqualTo(LocalDate.now());
+  }
+
+  @Test
+  @DisplayName("createFromReview: 텍스트 리뷰 등록 시 텍스트 리뷰 포인트 생성")
+  void createFromReview_TextReview() {
+
+    // given
+    Review reviewWithoutImage = Review.builder()
+        .user(createMockUser())
+        .place(createMockPlace())
+        .content("Nice place!")
+        .rating(4)
+        .imageUrl(null)
+        .build();
+
+    // when
+    Point point = Point.createFromReview(reviewWithoutImage);
+
+    // then
+    // 텍스트 리뷰 적립 확인
+    assertThat(point.getAmount()).isEqualTo(PointPolicy.REVIEW_TEXT_POINTS.getValue());
+
+    // 적립 포인트 설명 확인
+    assertThat(point.getDescription()).isEqualTo(PointDescription.REVIEW_TEXT);
+  }
+
+  @Test
+  @DisplayName("createFromReview: 공백 이미지 URL인 경우 텍스트 리뷰 포인트 생성")
+  void createFromReview_BlankImageUrl() {
+    // given
+    Review reviewWithBlankImage = Review.builder()
+        .user(createMockUser())
+        .place(createMockPlace())
+        .content("Average place.")
+        .rating(3)
+        .imageUrl("   ") // 공백 이미지 URL (빈 문자열 포함)
+        .build();
+
+    // when
+    Point point = Point.createFromReview(reviewWithBlankImage);
+
+    // then
+    // 텍스트 리뷰 적립 확인
+    assertThat(point.getAmount()).isEqualTo(PointPolicy.REVIEW_TEXT_POINTS.getValue());
+
+    // 적립 포인트 설명 확인
+    assertThat(point.getDescription()).isEqualTo(PointDescription.REVIEW_TEXT);
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #164 

## 📝 변경 사항
### AS-IS
- Point 엔티티의 핵심 팩토리 메서드(`createFromReview`)와 PointTransaction DTO의 복잡한 변환 로직에 대한 테스트가 부재함.
- 포인트 정책(Enum) 변경 시, 적립 금액이 올바르게 반영되는지 확인할 방법이 없었음.

### TO-BE
**1. Point 엔티티 로직 테스트 추가**
- `PointTest.java`에 `createFromReview` 테스트를 추가하고, **PointPolicy enum 값**을 직접 참조하여 리뷰 이미지 유무에 따른 적립 금액(100점/50점) 및 설명(REVIEW_PHOTO/TEXT)이 정확히 설정됨을 검증.

**2. Point DTO 변환 로직 검증**
- `PointTransactionTest.java`에서 생성자 테스트를 통해:
    - `PointDescription.REVIEW_PHOTO` 시 `hasImage`가 `true`가 되는지 검증.
    - `PlaceInfo` 객체가 내부적으로 정확히 생성되는지 검증.
- `PointHistoryResponseTest.java` 및 `PlaceInfoTest.java`를 통해 응답 데이터 매핑의 정확성 확보.

**3. 테스트 안정성 확보**
- 테스트 코드에서 **Enum 상수**를 직접 사용하여, 비즈니스 로직과 테스트 코드의 **정합성(Consistency)**을 높였습니다.

## 🔍 테스트
- [x] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
<img width="247" height="50" alt="image" src="https://github.com/user-attachments/assets/d83eaccc-359c-4703-bfe5-774fd5918149" />
<img width="337" height="50" alt="image" src="https://github.com/user-attachments/assets/49da402a-a44c-4a3f-bd30-1d2f15da3d57" />
<img width="314" height="42" alt="image" src="https://github.com/user-attachments/assets/4a4f464e-135e-41a8-8c40-cc942db9f36d" />
<img width="233" height="50" alt="image" src="https://github.com/user-attachments/assets/f6a1305a-1eb1-4e8a-aa05-0da401d73050" />


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
다들 파이팅입니다 💪


