### PR TITLE
[Test] BookmarkService & PlaceService 단위 테스트 추가

### DIFF
--- a/backend/src/test/java/com/backend/petplace/domain/bookmark/service/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/backend/petplace/domain/bookmark/service/BookmarkServiceTest.java
@@ -283,7 +283,6 @@ class BookmarkServiceTest {
       Place placeA = createPlace(10L, "AAA 병원");
       Place placeB = createPlace(20L, "BBB 카페");
 
-      // ✅ 여기 수정
       given(placeRepository.findAllById(anyList()))
           .willReturn(new ArrayList<>(List.of(placeB, placeA)));
       // 또는 Arrays.asList(placeB, placeA) 도 됨

--- a/backend/src/test/java/com/backend/petplace/domain/bookmark/service/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/backend/petplace/domain/bookmark/service/BookmarkServiceTest.java
@@ -1,0 +1,384 @@
+package com.backend.petplace.domain.bookmark.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.verify;
+
+import com.backend.petplace.domain.bookmark.dto.response.MyBookmarkPlaceResponse;
+import com.backend.petplace.domain.bookmark.entity.Bookmark;
+import com.backend.petplace.domain.bookmark.repository.BookmarkRepository;
+import com.backend.petplace.domain.place.entity.Place;
+import com.backend.petplace.domain.place.repository.PlaceRepository;
+import com.backend.petplace.domain.user.entity.User;
+import com.backend.petplace.domain.user.repository.UserRepository;
+import com.backend.petplace.global.exception.BusinessException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class BookmarkServiceTest {
+
+  private static final String BOOKMARK_USER_KEY_PREFIX = "bookmark:user:";
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private PlaceRepository placeRepository;
+
+  @Mock
+  private BookmarkRepository bookmarkRepository;
+
+  @Mock
+  private StringRedisTemplate stringRedisTemplate;
+
+  @Mock
+  private SetOperations<String, String> setOperations;
+
+  @InjectMocks
+  private BookmarkService bookmarkService;
+
+  private User createUser(Long id) {
+    // 실제 엔티티 사용 (mock 아님) → 불필요 stubbing 방지
+    return User.builder()
+        .id(id)
+        .build();
+  }
+
+  private Place createPlace(Long id, String name) {
+    return Place.builder()
+        .id(id)
+        .name(name)
+        .build();
+  }
+
+  @BeforeEach
+  void setUp() {
+    // 여기서는 opsForSet 미리 stub 안 함 (어떤 테스트에서는 안 쓰여서 UnnecessaryStubbing 발생)
+  }
+
+  @Nested
+  @DisplayName("addBookmark()")
+  class AddBookmark {
+
+    @Test
+    @DisplayName("성공 - 유저/장소 존재 & 아직 북마크 안 되어 있으면 저장 후 Redis에 추가")
+    void addBookmark_success() {
+      // given
+      Long userId = 1L;
+      Long placeId = 10L;
+      User user = createUser(userId);
+      Place place = createPlace(placeId, "행복동물병원");
+
+      given(userRepository.findById(userId)).willReturn(Optional.of(user));
+      given(placeRepository.findById(placeId)).willReturn(Optional.of(place));
+      given(bookmarkRepository.existsByUserIdAndPlace_Id(userId, placeId)).willReturn(false);
+
+      Bookmark saved = Bookmark.builder()
+          .id(100L)
+          .userId(userId)
+          .place(place)
+          .build();
+
+      // 서비스 안에서 Bookmark.createNewBookmark(...)로 새 인스턴스를 만들어서 save에 넘기기 때문에
+      // 정확한 인스턴스로 stub 하면 안 되고 any(Bookmark.class)로 받아야 함
+      given(bookmarkRepository.save(any(Bookmark.class))).willReturn(saved);
+
+      given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+
+      // when
+      Long resultId = bookmarkService.addBookmark(userId, placeId);
+
+      // then
+      assertEquals(100L, resultId);
+
+      String key = BOOKMARK_USER_KEY_PREFIX + userId;
+      verify(setOperations).add(key, placeId.toString());
+      verify(bookmarkRepository).save(any(Bookmark.class));
+    }
+
+    @Test
+    @DisplayName("실패 - 유저가 존재하지 않으면 BusinessException 발생")
+    void addBookmark_fail_userNotFound() {
+      // given
+      Long userId = 1L;
+      Long placeId = 10L;
+      given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+      // when & then
+      assertThrows(BusinessException.class,
+          () -> bookmarkService.addBookmark(userId, placeId));
+
+      verify(bookmarkRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("실패 - 장소가 존재하지 않으면 BusinessException 발생")
+    void addBookmark_fail_placeNotFound() {
+      // given
+      Long userId = 1L;
+      Long placeId = 10L;
+      User user = createUser(userId);
+
+      given(userRepository.findById(userId)).willReturn(Optional.of(user));
+      given(placeRepository.findById(placeId)).willReturn(Optional.empty());
+
+      // when & then
+      assertThrows(BusinessException.class,
+          () -> bookmarkService.addBookmark(userId, placeId));
+
+      verify(bookmarkRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("실패 - 이미 북마크 되어 있으면 BusinessException 발생")
+    void addBookmark_fail_alreadyBookmarked() {
+      // given
+      Long userId = 1L;
+      Long placeId = 10L;
+      User user = createUser(userId);
+      Place place = createPlace(placeId, "행복동물병원");
+
+      given(userRepository.findById(userId)).willReturn(Optional.of(user));
+      given(placeRepository.findById(placeId)).willReturn(Optional.of(place));
+      given(bookmarkRepository.existsByUserIdAndPlace_Id(userId, placeId)).willReturn(true);
+
+      // when & then
+      assertThrows(BusinessException.class,
+          () -> bookmarkService.addBookmark(userId, placeId));
+
+      verify(bookmarkRepository, never()).save(any());
+    }
+  }
+
+  @Nested
+  @DisplayName("removeBookmark()")
+  class RemoveBookmark {
+
+    @Test
+    @DisplayName("성공 - 유저/장소/북마크 모두 존재하면 삭제 후 Redis에서 제거")
+    void removeBookmark_success() {
+      // given
+      Long userId = 1L;
+      Long placeId = 10L;
+      User user = createUser(userId);
+      Place place = createPlace(placeId, "행복동물병원");
+
+      Bookmark bookmark = Bookmark.builder()
+          .id(100L)
+          .userId(userId)
+          .place(place)
+          .build();
+
+      given(userRepository.findById(userId)).willReturn(Optional.of(user));
+      given(placeRepository.findById(placeId)).willReturn(Optional.of(place));
+      given(bookmarkRepository.findByUserIdAndPlace_Id(userId, placeId))
+          .willReturn(Optional.of(bookmark));
+
+      given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+
+      // when
+      bookmarkService.removeBookmark(userId, placeId);
+
+      // then
+      verify(bookmarkRepository).delete(bookmark);
+
+      String key = BOOKMARK_USER_KEY_PREFIX + userId;
+      verify(setOperations).remove(key, placeId.toString());
+    }
+
+    @Test
+    @DisplayName("실패 - 유저가 존재하지 않으면 BusinessException 발생")
+    void removeBookmark_fail_userNotFound() {
+      // given
+      Long userId = 1L;
+      Long placeId = 10L;
+
+      given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+      // when & then
+      assertThrows(BusinessException.class,
+          () -> bookmarkService.removeBookmark(userId, placeId));
+
+      verify(bookmarkRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("실패 - 장소가 존재하지 않으면 BusinessException 발생")
+    void removeBookmark_fail_placeNotFound() {
+      // given
+      Long userId = 1L;
+      Long placeId = 10L;
+      User user = createUser(userId);
+
+      given(userRepository.findById(userId)).willReturn(Optional.of(user));
+      given(placeRepository.findById(placeId)).willReturn(Optional.empty());
+
+      // when & then
+      assertThrows(BusinessException.class,
+          () -> bookmarkService.removeBookmark(userId, placeId));
+
+      verify(bookmarkRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("실패 - 북마크가 존재하지 않으면 BusinessException 발생")
+    void removeBookmark_fail_bookmarkNotFound() {
+      // given
+      Long userId = 1L;
+      Long placeId = 10L;
+      User user = createUser(userId);
+      Place place = createPlace(placeId, "행복동물병원");
+
+      given(userRepository.findById(userId)).willReturn(Optional.of(user));
+      given(placeRepository.findById(placeId)).willReturn(Optional.of(place));
+      given(bookmarkRepository.findByUserIdAndPlace_Id(userId, placeId))
+          .willReturn(Optional.empty());
+
+      // when & then
+      assertThrows(BusinessException.class,
+          () -> bookmarkService.removeBookmark(userId, placeId));
+
+      verify(bookmarkRepository, never()).delete(any());
+    }
+  }
+
+  @Nested
+  @DisplayName("getMyBookmarks()")
+  class GetMyBookmarks {
+
+    @Test
+    @DisplayName("성공 - 캐시 히트 시 Redis에서 placeId Set 조회 후 Place로 변환하여 정렬된 응답 반환")
+    void getMyBookmarks_cacheHit() {
+      // given
+      Long userId = 1L;
+      User user = createUser(userId);
+
+      given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+      String key = BOOKMARK_USER_KEY_PREFIX + userId;
+      Set<String> cachedIds = Set.of("10", "20");
+      given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+      given(setOperations.members(key)).willReturn(cachedIds);
+
+      Place placeA = createPlace(10L, "AAA 병원");
+      Place placeB = createPlace(20L, "BBB 카페");
+
+      // ✅ 여기 수정
+      given(placeRepository.findAllById(anyList()))
+          .willReturn(new ArrayList<>(List.of(placeB, placeA)));
+      // 또는 Arrays.asList(placeB, placeA) 도 됨
+
+      // when
+      List<MyBookmarkPlaceResponse> results = bookmarkService.getMyBookmarks(userId);
+
+      // then - 이름 오름차순으로 정렬되었는지 확인
+      assertEquals(2, results.size());
+      assertEquals("AAA 병원", results.get(0).name());
+      assertEquals("BBB 카페", results.get(1).name());
+    }
+
+    @Test
+    @DisplayName("성공 - 캐시 미스 시 DB에서 북마크+장소 조회 후 Redis에 적재하고 응답")
+    void getMyBookmarks_cacheMiss_thenLoadFromDb() {
+      // given
+      Long userId = 1L;
+      User user = createUser(userId);
+
+      given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+      String key = BOOKMARK_USER_KEY_PREFIX + userId;
+      given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+      // 캐시 미스: null 또는 빈 Set
+      given(setOperations.members(key)).willReturn(null);
+
+      Place place1 = createPlace(10L, "AAA 병원");
+      Place place2 = createPlace(20L, "BBB 카페");
+
+      Bookmark bookmark1 = Bookmark.builder()
+          .id(100L)
+          .userId(userId)
+          .place(place1)
+          .build();
+      Bookmark bookmark2 = Bookmark.builder()
+          .id(200L)
+          .userId(userId)
+          .place(place2)
+          .build();
+
+      given(bookmarkRepository.findAllByUserIdWithPlace(userId))
+          .willReturn(List.of(bookmark1, bookmark2));
+
+      // when
+      List<MyBookmarkPlaceResponse> results = bookmarkService.getMyBookmarks(userId);
+
+      // then
+      assertEquals(2, results.size());
+      // Bookmark 순서 그대로 매핑
+      assertEquals(place1.getId(), results.get(0).placeId());
+      assertEquals(place2.getId(), results.get(1).placeId());
+
+      // Redis에 placeId들 적재
+      verify(setOperations).add(key, "10", "20");
+    }
+
+    @Test
+    @DisplayName("성공 - 캐시 미스 & 북마크가 하나도 없으면 빈 리스트 반환 및 Redis 적재 안 함")
+    void getMyBookmarks_cacheMiss_andNoBookmarks() {
+      // given
+      Long userId = 1L;
+      User user = createUser(userId);
+
+      given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+      String key = BOOKMARK_USER_KEY_PREFIX + userId;
+      given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+      given(setOperations.members(key)).willReturn(null);
+      given(bookmarkRepository.findAllByUserIdWithPlace(userId))
+          .willReturn(List.of());
+
+      // when
+      List<MyBookmarkPlaceResponse> results = bookmarkService.getMyBookmarks(userId);
+
+      // then
+      assertNotNull(results);
+      assertTrue(results.isEmpty());
+
+      verify(setOperations, never()).add(eq(key), any());
+    }
+
+    @Test
+    @DisplayName("실패 - 유저가 존재하지 않으면 BusinessException 발생")
+    void getMyBookmarks_fail_userNotFound() {
+      // given
+      Long userId = 1L;
+      given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+      // when & then
+      assertThrows(BusinessException.class,
+          () -> bookmarkService.getMyBookmarks(userId));
+
+      // Redis 쪽은 전혀 호출되지 않아야 함
+      verify(stringRedisTemplate, never()).opsForSet();
+    }
+  }
+}

--- a/backend/src/test/java/com/backend/petplace/domain/place/PlaceServiceTest.java
+++ b/backend/src/test/java/com/backend/petplace/domain/place/PlaceServiceTest.java
@@ -1,0 +1,397 @@
+package com.backend.petplace.domain.place;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+
+import com.backend.petplace.domain.place.dto.response.PlaceDetailResponse;
+import com.backend.petplace.domain.place.dto.response.PlaceSearchResponse;
+import com.backend.petplace.domain.place.entity.Category1Type;
+import com.backend.petplace.domain.place.entity.Category2Type;
+import com.backend.petplace.domain.place.entity.Place;
+import com.backend.petplace.domain.place.projection.PlaceSearchRow;
+import com.backend.petplace.domain.place.repository.PlaceRepository;
+import com.backend.petplace.domain.place.service.PlaceService;
+import com.backend.petplace.global.exception.BusinessException;
+import com.backend.petplace.global.response.ErrorCode;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PlaceServiceTest {
+
+  @Mock
+  private PlaceRepository placeRepository;
+
+  @InjectMocks
+  private PlaceService placeService;
+
+  /**
+   * 검색 쿼리 결과를 흉내 내기 위한 테스트용 구현체
+   */
+  private static class TestPlaceSearchRow implements PlaceSearchRow {
+    private final Long id;
+    private final String name;
+    private final String category2;
+    private final Double latitude;
+    private final Double longitude;
+    private final Integer distanceMeters;
+    private final Double averageRating;
+    private final String address;
+
+    private TestPlaceSearchRow(
+        Long id,
+        String name,
+        String category2,
+        Double latitude,
+        Double longitude,
+        Integer distanceMeters,
+        Double averageRating,
+        String address
+    ) {
+      this.id = id;
+      this.name = name;
+      this.category2 = category2;
+      this.latitude = latitude;
+      this.longitude = longitude;
+      this.distanceMeters = distanceMeters;
+      this.averageRating = averageRating;
+      this.address = address;
+    }
+
+    public static TestPlaceSearchRow of(
+        Long id,
+        String name,
+        Category2Type category2,
+        Double latitude,
+        Double longitude,
+        Integer distanceMeters,
+        Double averageRating,
+        String address
+    ) {
+      return new TestPlaceSearchRow(
+          id,
+          name,
+          category2.name(),
+          latitude,
+          longitude,
+          distanceMeters,
+          averageRating,
+          address
+      );
+    }
+
+    @Override public Long getId() { return id; }
+    @Override public String getName() { return name; }
+    @Override public String getCategory2() { return category2; }
+    @Override public Double getLatitude() { return latitude; }
+    @Override public Double getLongitude() { return longitude; }
+    @Override public Integer getDistanceMeters() { return distanceMeters; }
+    @Override public Double getAverageRating() { return averageRating; }
+    @Override public String getAddress() { return address; }
+  }
+
+  @Nested
+  @DisplayName("searchPlaces()")
+  class SearchPlaces {
+
+    @Test
+    @DisplayName("성공 - radiusKm, category2, keyword 모두 없으면 기본 반경(10km) + 필터 없이 검색")
+    void searchPlaces_defaultRadius_noFilters() {
+      // given
+      double lat = 37.5665;
+      double lon = 126.9780;
+      Integer radiusKm = null;
+      List<Category2Type> category2List = null;
+      String keyword = null;
+
+      // 리포지토리에서 반환해 줄 더미 Row
+      PlaceSearchRow row1 = TestPlaceSearchRow.of(
+          1L, "행복동물병원", Category2Type.VET_HOSPITAL,
+          lat, lon, 500, 4.5, "서울 어딘가 1"
+      );
+      PlaceSearchRow row2 = TestPlaceSearchRow.of(
+          2L, "즐거운카페", Category2Type.VET_HOSPITAL,
+          lat, lon, 800, 4.0, "서울 어딘가 2"
+      );
+
+      given(placeRepository.searchWithinRadius(
+          anyDouble(), anyDouble(),
+          anyDouble(), anyDouble(),
+          anyDouble(), anyDouble(),
+          anyInt(),
+          anyList(),
+          anyInt(),
+          any(),     // keyword
+          anyInt(),
+          anyInt()
+      )).willReturn(List.of(row1, row2));
+
+      // when
+      List<PlaceSearchResponse> results = placeService.searchPlaces(
+          lat, lon, radiusKm, category2List, keyword
+      );
+
+      // then: 결과 매핑 확인
+      assertEquals(2, results.size());
+
+      PlaceSearchResponse r1 = results.get(0);
+      assertEquals(1L, r1.id());
+      assertEquals("행복동물병원", r1.name());
+      assertEquals(Category2Type.VET_HOSPITAL, r1.category2());
+      assertEquals(500, r1.distanceMeters());
+      assertEquals(4.5, r1.averageRating());
+      assertEquals("서울 어딘가 1", r1.address());
+
+      PlaceSearchResponse r2 = results.get(1);
+      assertEquals(2L, r2.id());
+      assertEquals("즐거운카페", r2.name());
+
+      // then: 리포지토리에 전달된 파라미터 검증
+      ArgumentCaptor<Double> latCaptor = ArgumentCaptor.forClass(Double.class);
+      ArgumentCaptor<Double> lonCaptor = ArgumentCaptor.forClass(Double.class);
+      ArgumentCaptor<Double> minLatCaptor = ArgumentCaptor.forClass(Double.class);
+      ArgumentCaptor<Double> maxLatCaptor = ArgumentCaptor.forClass(Double.class);
+      ArgumentCaptor<Double> minLonCaptor = ArgumentCaptor.forClass(Double.class);
+      ArgumentCaptor<Double> maxLonCaptor = ArgumentCaptor.forClass(Double.class);
+      ArgumentCaptor<Integer> radiusMetersCaptor = ArgumentCaptor.forClass(Integer.class);
+      ArgumentCaptor<List<String>> cat2ListCaptor = ArgumentCaptor.forClass(List.class);
+      ArgumentCaptor<Integer> cat2CountCaptor = ArgumentCaptor.forClass(Integer.class);
+      ArgumentCaptor<String> keywordCaptor = ArgumentCaptor.forClass(String.class);
+      ArgumentCaptor<Integer> limitCaptor = ArgumentCaptor.forClass(Integer.class);
+      ArgumentCaptor<Integer> offsetCaptor = ArgumentCaptor.forClass(Integer.class);
+
+      verify(placeRepository).searchWithinRadius(
+          latCaptor.capture(),
+          lonCaptor.capture(),
+          minLatCaptor.capture(),
+          maxLatCaptor.capture(),
+          minLonCaptor.capture(),
+          maxLonCaptor.capture(),
+          radiusMetersCaptor.capture(),
+          cat2ListCaptor.capture(),
+          cat2CountCaptor.capture(),
+          keywordCaptor.capture(),
+          limitCaptor.capture(),
+          offsetCaptor.capture()
+      );
+
+      // 기본 반경 10km → 10,000m
+      assertEquals(10_000, radiusMetersCaptor.getValue());
+      // category2List 없으므로 빈 리스트 + count 0
+      assertEquals(0, cat2ListCaptor.getValue().size());
+      assertEquals(0, cat2CountCaptor.getValue());
+      // keyword 없음 → null
+      assertEquals(null, keywordCaptor.getValue());
+      // limit / offset 기본값
+      assertEquals(300, limitCaptor.getValue());
+      assertEquals(0, offsetCaptor.getValue());
+      // lat / lon 그대로 들어갔는지
+      assertEquals(lat, latCaptor.getValue());
+      assertEquals(lon, lonCaptor.getValue());
+    }
+
+    @Test
+    @DisplayName("성공 - radiusKm가 MAX(30km)를 넘으면 30km로 캡핑, Category2/keyword 필터 정상 적용")
+    void searchPlaces_radiusOverMax_andFilters() {
+      // given
+      double lat = 37.0;
+      double lon = 127.0;
+      Integer radiusKm = 50; // MAX_RADIUS_KM = 30 → 30km로 캡핑
+      List<Category2Type> category2List = List.of(Category2Type.VET_HOSPITAL);
+      String keyword = "  병원  "; // 앞뒤 공백 → trim 후 "병원"
+
+      PlaceSearchRow row = TestPlaceSearchRow.of(
+          1L, "병원A", Category2Type.VET_HOSPITAL,
+          lat, lon, 1000, 4.2, "주소 A"
+      );
+
+      given(placeRepository.searchWithinRadius(
+          anyDouble(), anyDouble(),
+          anyDouble(), anyDouble(),
+          anyDouble(), anyDouble(),
+          anyInt(),
+          anyList(),
+          anyInt(),
+          any(),
+          anyInt(),
+          anyInt()
+      )).willReturn(List.of(row));
+
+      // when
+      List<PlaceSearchResponse> results = placeService.searchPlaces(
+          lat, lon, radiusKm, category2List, keyword
+      );
+
+      // then: 매핑 확인
+      assertEquals(1, results.size());
+      assertEquals(1L, results.get(0).id());
+      assertEquals("병원A", results.get(0).name());
+      assertEquals(Category2Type.VET_HOSPITAL, results.get(0).category2());
+
+      // then: 실제 전달된 파라미터 검증
+      ArgumentCaptor<Integer> radiusMetersCaptor = ArgumentCaptor.forClass(Integer.class);
+      ArgumentCaptor<List<String>> cat2ListCaptor = ArgumentCaptor.forClass(List.class);
+      ArgumentCaptor<Integer> cat2CountCaptor = ArgumentCaptor.forClass(Integer.class);
+      ArgumentCaptor<String> keywordCaptor = ArgumentCaptor.forClass(String.class);
+
+      verify(placeRepository).searchWithinRadius(
+          anyDouble(), anyDouble(),
+          anyDouble(), anyDouble(),
+          anyDouble(), anyDouble(),
+          radiusMetersCaptor.capture(),
+          cat2ListCaptor.capture(),
+          cat2CountCaptor.capture(),
+          keywordCaptor.capture(),
+          anyInt(),
+          anyInt()
+      );
+
+      // 30km로 캡핑 → 30,000m
+      assertEquals(30_000, radiusMetersCaptor.getValue());
+      // Category2Type → String name() 으로 변환
+      List<String> cat2 = cat2ListCaptor.getValue();
+      assertEquals(1, cat2.size());
+      assertEquals(Category2Type.VET_HOSPITAL.name(), cat2.get(0));
+      assertEquals(1, cat2CountCaptor.getValue());
+      // keyword는 trim 후 들어가야 함
+      assertEquals("병원", keywordCaptor.getValue());
+    }
+
+    @Test
+    @DisplayName("성공 - keyword가 공백 문자열이면 NULL로 처리하여 이름 필터를 적용하지 않는다")
+    void searchPlaces_blankKeyword_treatedAsNull() {
+      // given
+      double lat = 37.5;
+      double lon = 127.1;
+      Integer radiusKm = 5;
+      List<Category2Type> category2List = List.of(Category2Type.VET_HOSPITAL);
+      String keyword = "   "; // 공백만
+
+      PlaceSearchRow row = TestPlaceSearchRow.of(
+          1L, "병원B", Category2Type.VET_HOSPITAL,
+          lat, lon, 1200, 4.7, "주소 B"
+      );
+
+      given(placeRepository.searchWithinRadius(
+          anyDouble(), anyDouble(),
+          anyDouble(), anyDouble(),
+          anyDouble(), anyDouble(),
+          anyInt(),
+          anyList(),
+          anyInt(),
+          any(),
+          anyInt(),
+          anyInt()
+      )).willReturn(List.of(row));
+
+      // when
+      placeService.searchPlaces(lat, lon, radiusKm, category2List, keyword);
+
+      // then
+      ArgumentCaptor<String> keywordCaptor = ArgumentCaptor.forClass(String.class);
+      verify(placeRepository).searchWithinRadius(
+          anyDouble(), anyDouble(),
+          anyDouble(), anyDouble(),
+          anyDouble(), anyDouble(),
+          anyInt(),
+          anyList(),
+          anyInt(),
+          keywordCaptor.capture(),
+          anyInt(),
+          anyInt()
+      );
+
+      // 공백 문자열 → null 로 전달되어야 함
+      assertEquals(null, keywordCaptor.getValue());
+    }
+  }
+
+  @Nested
+  @DisplayName("getPlaceDetail()")
+  class GetPlaceDetail {
+
+    @Test
+    @DisplayName("성공 - placeId로 조회 성공 시 PlaceDetailResponse로 매핑하여 반환")
+    void getPlaceDetail_success() {
+      // given
+      Long placeId = 1L;
+
+      Place place = Place.builder()
+          .id(placeId)
+          .uniqueKey("UNIQ_001")
+          .name("행복동물병원")
+          .category1(Category1Type.PET_MEDICAL)
+          .category2(Category2Type.VET_HOSPITAL)
+          .openingHours("월~금 09:00~18:00")
+          .closedDays("토/일 휴무")
+          .parking(true)
+          .petAllowed(true)
+          .petRestriction("소형견만")
+          .tel("02-123-4567")
+          .url("https://example.com")
+          .postalCode("06236")
+          .address("서울시 어딘가 1")
+          .latitude(37.0)
+          .longitude(127.0)
+          .rawDescription("원본 설명")
+          .averageRating(4.5)
+          .totalReviewCount(10)
+          .build();
+
+      given(placeRepository.findById(placeId)).willReturn(Optional.of(place));
+
+      // when
+      PlaceDetailResponse response = placeService.getPlaceDetail(placeId);
+
+      // then
+      assertEquals(place.getId(), response.id());
+      assertEquals(place.getName(), response.name());
+      assertEquals(place.getCategory1(), response.category1());
+      assertEquals(place.getCategory2(), response.category2());
+      assertEquals(place.getOpeningHours(), response.openingHours());
+      assertEquals(place.getClosedDays(), response.closedDays());
+      assertEquals(place.getParking(), response.parking());
+      assertEquals(place.getPetAllowed(), response.petAllowed());
+      assertEquals(place.getPetRestriction(), response.petRestriction());
+      assertEquals(place.getTel(), response.tel());
+      assertEquals(place.getUrl(), response.url());
+      assertEquals(place.getPostalCode(), response.postalCode());
+      assertEquals(place.getAddress(), response.address());
+      assertEquals(place.getLatitude(), response.latitude());
+      assertEquals(place.getLongitude(), response.longitude());
+      assertEquals(place.getAverageRating(), response.averageRating());
+      assertEquals(place.getTotalReviewCount(), response.totalReviewCount());
+      assertEquals(place.getRawDescription(), response.rawDescription());
+    }
+
+    @Test
+    @DisplayName("실패 - placeId로 조회 실패 시 BusinessException(NOT_FOUND_PLACE) 발생")
+    void getPlaceDetail_notFound() {
+      // given
+      Long placeId = 999L;
+      given(placeRepository.findById(placeId)).willReturn(Optional.empty());
+
+      // when & then
+      BusinessException ex = assertThrows(
+          BusinessException.class,
+          () -> placeService.getPlaceDetail(placeId)
+      );
+
+      assertEquals(ErrorCode.NOT_FOUND_PLACE, ex.getErrorCode());
+    }
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #168 

## 📝 변경 사항
### AS-IS
- BookmarkService, PlaceService에 대한 단위 테스트가 거의/전혀 없는 상태
- 북마크 캐시 로직, 장소 검색 파라미터 처리, 장소 상세 조회 예외 처리 등이 테스트로 검증되지 않음

### TO-BE
- `BookmarkServiceTest` 추가
  - `addBookmark()`
    - 유저/장소 존재 & 아직 북마크되지 않은 경우 → DB 저장 + Redis Set에 placeId 추가되는지 검증
    - 유저 미존재, 장소 미존재, 이미 북마크된 경우 각각 `BusinessException` 발생 검증
  - `removeBookmark()`
    - 유저/장소/북마크 존재 시 → DB delete + Redis Set remove 호출 검증
    - 유저 미존재, 장소 미존재, 북마크 미존재 시 `BusinessException` 발생 검증
  - `getMyBookmarks()`
    - 캐시 히트: Redis에서 placeId Set 조회 후 Place 목록으로 변환, 이름 기준 오름차순 정렬 확인
    - 캐시 미스: DB에서 북마크 + 장소 조회 후 Redis에 placeId 적재 및 응답 검증
    - 북마크가 없는 경우: 빈 리스트 반환 및 Redis에 add 호출이 없는지 검증
    - 유저 미존재 시: `BusinessException` 발생 및 Redis 호출이 없는지 검증

- `PlaceServiceTest` 추가
  - `searchPlaces()`
    - radiusKm, category2, keyword가 없을 때:
      - 기본 반경 10km (`radiusMeters = 10_000`)로 호출되는지 검증
      - category2 필터/keyword 필터 비활성화 상태 확인
    - radiusKm > 30인 경우:
      - 30km로 캡핑되어 `radiusMeters = 30_000`으로 전달되는지 검증
    - category2 리스트가 있는 경우:
      - Enum → String(`name()`) 변환 후 IN 조건 파라미터로 전달되는지 검증
    - keyword가 "  병원  "처럼 공백 포함 시:
      - `trim()` 처리된 `"병원"`으로 전달되는지 검증
    - keyword가 공백 문자열("   ")일 때:
      - `null`로 처리되어 이름 필터가 적용되지 않는지 검증
    - `PlaceSearchRow` → `PlaceSearchResponse` 매핑 검증
  - `getPlaceDetail()`
    - 정상 케이스:
      - Place 엔티티 조회 성공 시 `PlaceDetailResponse.from(place)`로 모든 필드가 정상 매핑되는지 검증
    - 예외 케이스:
      - Place 미존재 시 `BusinessException` 발생 및 `ErrorCode.NOT_FOUND_PLACE` 반환 검증


## 🔍 테스트
- [x] 테스트 코드 작성
- [ ] API 테스트
- [x] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
졸리네요..


